### PR TITLE
Implement int32_t log context property type and add log context property type interface

### DIFF
--- a/v2/CMakeLists.txt
+++ b/v2/CMakeLists.txt
@@ -3,11 +3,15 @@
 
 set(c_logging_v2_c_files
     ./src/logger.c
+    ./src/log_context_property_basic_types.c
     )
 
 set(c_logging_v2_h_files
     ./inc/c_logging/logger.h
     ./inc/c_logging/log_context.h
+    ./inc/c_logging/log_context_property_type.h
+    ./inc/c_logging/log_context_property_type_if.h
+    ./inc/c_logging/log_context_property_basic_types.h
     ./inc/c_logging/log_level.h
     ./inc/c_logging/log_sink_if.h
     )

--- a/v2/devdoc/log_context_property_basic_types_requirements.md
+++ b/v2/devdoc/log_context_property_basic_types_requirements.md
@@ -1,0 +1,85 @@
+# `log_context_property_basic_types` requirements
+
+`log_context_property_basic_types` is a collection of log context property interface concrete implementations that implement the code needed for handling basic types (integers, bool, etc.).
+
+The list of supported basic types is:
+
+- int64_t
+- uint64_t
+- int32_t
+- uint32_t
+- int16_t
+- uint16_t
+- int8_t
+- uint8_t
+
+Note: More types will be added as needed.
+
+## Exposed API
+
+```
+#define SUPPORTED_BASIC_TYPES \
+    int64_t, \
+    uint64_t, \
+    int32_t, \
+    uint32_t, \
+    int16_t, \
+    uint16_t, \
+    int8_t, \
+    uint8_t
+
+#define DECLARE_BASIC_TYPE(type_name) \
+    extern const LOG_CONTEXT_PROPERTY_TYPE_IF MU_C2(type_name, _log_context_property_type);
+
+MU_FOR_EACH_1(DECLARE_BASIC_TYPE, SUPPORTED_BASIC_TYPES)
+```
+
+## LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).to_string
+
+```c
+typedef int (*LOG_CONTEXT_PROPERTY_TYPE_TO_STRING)(void* property_value, char* buffer, size_t buffer_length);
+```
+
+`LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).to_string` produces the string representation of an `int64_t`.
+
+**SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_001: [** If `property_value` is `NULL`, `LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).to_string` shall fail and return -1. **]**
+
+**SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_002: [** `LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).to_string` shall call `snprintf` with `buffer`, `buffer_length` and format string `PRId64` and pass in the values list the `int64_t` value pointed to be `property_value`. **]**
+
+**SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_003: [** `LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).to_string` shall succeed and return the result of `snprintf`. **]**
+
+**SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_004: [** If any error is encountered, `LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).to_string` shall fail and return -1. **]**
+
+## LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).copy
+
+```c
+typedef int (*LOG_CONTEXT_PROPERTY_TYPE_COPY)(void* dst_value, void* src_value);
+```
+
+`LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).copy` copies the `int64_t` value from the address pointed by `src_value` to `dst_value`.
+
+**SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_005: [** If `src_value` is `NULL`, `LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).copy` shall fail and return a non-zero value. **]**
+
+**SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_006: [** If `dst_value` is `NULL`, `LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).copy` shall fail and return a non-zero value. **]**
+
+**SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_007: [** `LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).copy` shall copy the bytes of the `int64_t` value from the address pointed by `src_value` to `dst_value`. **]**
+
+**SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_008: [** `LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).copy` shall succeed and return 0. **]**
+
+## LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).free
+
+```c
+typedef int (*LOG_CONTEXT_PROPERTY_TYPE_COPY)(void* value);
+```
+
+**SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_009: [** `LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).free` shall return. **]**
+
+## LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).get_type
+
+```c
+typedef LOG_CONTEXT_PROPERTY_TYPE (*LOG_CONTEXT_PROPERTY_TYPE_GET_TYPE)(void);
+```
+
+**SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_010: [** `LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).get_type` shall returns the property type `LOG_CONTEXT_PROPERTY_TYPE_int64_t`. **]**
+
+Note: the rest of the types will be implemented by cloning int32_t, thus will be done in a separate PR.

--- a/v2/devdoc/log_context_property_type_if_requirements.md
+++ b/v2/devdoc/log_context_property_type_if_requirements.md
@@ -1,0 +1,68 @@
+# `log_context_property_type_if` requirements
+
+`log_context_property_type_if` is an interface that defines a set of APIs commonly used when working with types in the `c_logging` implementation:
+
+- to_string
+- copy
+- free
+- get_type
+
+## Exposed API
+
+```
+typedef int (*LOG_CONTEXT_PROPERTY_TYPE_TO_STRING)(void* property_value, char* buffer, size_t buffer_length);
+typedef int (*LOG_CONTEXT_PROPERTY_TYPE_COPY)(void* dst_value, void* src_value);
+typedef void (*LOG_CONTEXT_PROPERTY_TYPE_FREE)(void* value);
+typedef LOG_CONTEXT_PROPERTY_TYPE (*LOG_CONTEXT_PROPERTY_TYPE_GET_TYPE)(void);
+
+typedef struct LOG_CONTEXT_PROPERTY_TYPE_IF_TAG
+{
+    LOG_CONTEXT_PROPERTY_TYPE_TO_STRING to_string;
+    LOG_CONTEXT_PROPERTY_TYPE_COPY copy;
+    LOG_CONTEXT_PROPERTY_TYPE_FREE free;
+    LOG_CONTEXT_PROPERTY_TYPE_GET_TYPE get_type;
+} LOG_CONTEXT_PROPERTY_TYPE_IF;
+
+// a convenient macro for obtaining a certain type concrete implementation
+// in a consistent way
+#define LOG_CONTEXT_PROPERTY_TYPE_IMPL(type_name) \
+    MU_C2(type_name, _log_context_property_type)
+```
+
+## LOG_CONTEXT_PROPERTY_TYPE_TO_STRING
+
+```c
+typedef int (*LOG_CONTEXT_PROPERTY_TYPE_TO_STRING)(void* property_value, char* buffer, size_t buffer_length);
+```
+
+LOG_CONTEXT_PROPERTY_TYPE_TO_STRING produces the string representation of the value pointed to be `property_value`.
+
+The result is placed in `buffer`, while observing the size of `buffer` to be `buffer_length`.
+
+## LOG_CONTEXT_PROPERTY_TYPE_COPY
+
+```c
+typedef int (*LOG_CONTEXT_PROPERTY_TYPE_COPY)(void* dst_value, void* src_value);
+```
+
+`LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).copy` copies the value pointed by `src_value` to `dst_value`.
+
+## LOG_CONTEXT_PROPERTY_TYPE_COPY
+
+```c
+typedef int (*LOG_CONTEXT_PROPERTY_TYPE_COPY)(void* value);
+```
+
+`LOG_CONTEXT_PROPERTY_TYPE_COPY` releases any resources associated with `value`.
+
+## LOG_CONTEXT_PROPERTY_TYPE_GET_TYPE
+
+```c
+typedef LOG_CONTEXT_PROPERTY_TYPE (*LOG_CONTEXT_PROPERTY_TYPE_GET_TYPE)(void);
+```
+
+`LOG_CONTEXT_PROPERTY_TYPE_GET_TYPE` returns the implemented type as known by `c_logging`.
+
+## LOG_CONTEXT_PROPERTY_TYPE_IMPL(type_name)
+
+**SRS_LOG_CONTEXT_PROPERTY_TYPE_IF_01_001: [** `LOG_CONTEXT_PROPERTY_TYPE_IMPL(type_name)` shall produce the token `{type_name}_log_context_property_type`. **]**

--- a/v2/inc/c_logging/log_context_property_basic_types.h
+++ b/v2/inc/c_logging/log_context_property_basic_types.h
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#ifndef LOG_CONTEXT_PROPERTY_BASIC_TYPES_H
+#define LOG_CONTEXT_PROPERTY_BASIC_TYPES_H
+
+#ifdef __cplusplus
+#include <cstdint>
+#else
+#include <stdint.h>
+#endif
+
+#include "macro_utils/macro_utils.h"
+
+#include "c_logging/log_context_property_type_if.h"
+
+#define SUPPORTED_BASIC_TYPES \
+    int64_t, \
+    uint64_t, \
+    int32_t, \
+    uint32_t, \
+    int16_t, \
+    uint16_t, \
+    int8_t, \
+    uint8_t
+
+#define DECLARE_BASIC_TYPE(type_name) \
+    extern const LOG_CONTEXT_PROPERTY_TYPE_IF MU_C2(type_name, _log_context_property_type);
+
+MU_FOR_EACH_1(DECLARE_BASIC_TYPE, SUPPORTED_BASIC_TYPES)
+
+#endif /* LOG_CONTEXT_PROPERTY_BASIC_TYPES_H */

--- a/v2/inc/c_logging/log_context_property_type.h
+++ b/v2/inc/c_logging/log_context_property_type.h
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#ifndef LOG_CONTEXT_PROPERTY_TYPE_H
+#define LOG_CONTEXT_PROPERTY_TYPE_H
+
+#include "macro_utils/macro_utils.h"
+
+#define LOG_CONTEXT_PROPERTY_TYPE_VALUES \
+    LOG_CONTEXT_PROPERTY_TYPE_int64_t, \
+    LOG_CONTEXT_PROPERTY_TYPE_uint64_t, \
+    LOG_CONTEXT_PROPERTY_TYPE_int32_t, \
+    LOG_CONTEXT_PROPERTY_TYPE_uint32_t, \
+    LOG_CONTEXT_PROPERTY_TYPE_int16_t, \
+    LOG_CONTEXT_PROPERTY_TYPE_uint16_t, \
+    LOG_CONTEXT_PROPERTY_TYPE_int8_t, \
+    LOG_CONTEXT_PROPERTY_TYPE_uint8_t \
+
+MU_DEFINE_ENUM(LOG_CONTEXT_PROPERTY_TYPE, LOG_CONTEXT_PROPERTY_TYPE_VALUES)
+
+#endif /* LOG_CONTEXT_PROPERTY_TYPE_H */

--- a/v2/inc/c_logging/log_context_property_type_if.h
+++ b/v2/inc/c_logging/log_context_property_type_if.h
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#ifndef LOG_CONTEXT_PROPERTY_TYPE_IF_H
+#define LOG_CONTEXT_PROPERTY_TYPE_IF_H
+
+#ifdef __cplusplus
+#include <cstdlib>
+#else
+#include <stdlib.h>
+#endif
+
+#include "c_logging/log_context_property_type.h"
+
+typedef int (*LOG_CONTEXT_PROPERTY_TYPE_TO_STRING)(void* property_value, char* buffer, size_t buffer_length);
+typedef int (*LOG_CONTEXT_PROPERTY_TYPE_COPY)(void* dst_value, void* src_value);
+typedef void (*LOG_CONTEXT_PROPERTY_TYPE_FREE)(void* value);
+typedef LOG_CONTEXT_PROPERTY_TYPE (*LOG_CONTEXT_PROPERTY_TYPE_GET_TYPE)(void);
+
+typedef struct LOG_CONTEXT_PROPERTY_TYPE_IF_TAG
+{
+    LOG_CONTEXT_PROPERTY_TYPE_TO_STRING to_string;
+    LOG_CONTEXT_PROPERTY_TYPE_COPY copy;
+    LOG_CONTEXT_PROPERTY_TYPE_FREE free;
+    LOG_CONTEXT_PROPERTY_TYPE_GET_TYPE get_type;
+} LOG_CONTEXT_PROPERTY_TYPE_IF;
+
+// a convenient macro for obtaining a certain type concrete implementation
+// in a consistent way
+/* Codes_SRS_LOG_CONTEXT_PROPERTY_TYPE_IF_01_001: [ LOG_CONTEXT_PROPERTY_TYPE_IMPL(type_name) shall produce the token {type_name}_log_context_property_type. ]*/
+#define LOG_CONTEXT_PROPERTY_TYPE_IMPL(type_name) \
+    MU_C2(type_name, _log_context_property_type)
+
+#endif /* LOG_CONTEXT_PROPERTY_TYPE_IF_H */

--- a/v2/src/log_context_property_basic_types.c
+++ b/v2/src/log_context_property_basic_types.c
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include <inttypes.h>
+#include <stdio.h>
+
+#include "macro_utils/macro_utils.h"
+
+#include "c_logging/log_context_property_type.h"
+#include "c_logging/log_context_property_type_if.h"
+#include "c_logging/log_context_property_basic_types.h"
+
+#define DEFINE_BASIC_TYPE_TO_STRING(type_name, print_format_string) \
+    static int MU_C2(type_name,_log_context_property_to_string)(void* property_value, char* buffer, size_t buffer_size) \
+    { \
+        int result; \
+        /* Codes_SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_001: [ If property_value is NULL, LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).to_string shall fail and return -1. ]*/ \
+        if (property_value == NULL) \
+        { \
+            (void)printf("Invalid arguments: void* property_value=%p, char* buffer=%p, size_t buffer_size=%zu\r\n", \
+                property_value, buffer, buffer_size); \
+            result = -1; \
+        } \
+        else \
+        { \
+            /* Codes_SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_002: [ LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).to_string shall call snprintf with buffer, buffer_length and format string PRId64 and pass in the values list the int64_t value pointed to be property_value. ]*/ \
+            /* Codes_SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_003: [ LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).to_string shall succeed and return the result of snprintf. ]*/ \
+            /* Codes_SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_004: [ If any error is encountered, LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).to_string shall fail and return -1. ]*/ \
+            result = snprintf(buffer, buffer_size, "%" print_format_string "", *(type_name*)property_value); \
+        } \
+        return result; \
+    } \
+
+#define DEFINE_BASIC_TYPE_COPY(type_name) \
+    static int MU_C2(type_name,_log_context_property_copy)(void* dst_value, void* src_value) \
+    { \
+        int result; \
+        if ( \
+            /* Codes_SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_005: [ If src_value is NULL, LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).copy shall fail and return a non-zero value. ]*/ \
+            (dst_value == NULL) || \
+            /* Codes_SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_006: [ If dst_value is NULL, LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).copy shall fail and return a non-zero value. ]*/ \
+            (src_value == NULL) \
+            ) \
+        { \
+            (void)printf("Invalid arguments: void* dst_value = %p, void* src_value = %p", \
+                dst_value, src_value); \
+            result = MU_FAILURE; \
+        } \
+        else \
+        { \
+            /* Codes_SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_007: [ LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).copy shall copy the bytes of the int64_t value from the address pointed by src_value to dst_value. ]*/ \
+            *(type_name*)dst_value = *(type_name*)src_value; \
+            /* Codes_SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_008: [ LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).copy shall succeed and return 0. ]*/ \
+            result = 0; \
+        } \
+        return result; \
+    } \
+
+#define DEFINE_BASIC_TYPE_FREE(type_name) \
+    static void MU_C2(type_name,_log_context_property_free)(void* value) \
+    { \
+        /* Codes_SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_009: [ LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).free shall return. ]*/ \
+        (void)value; \
+    } \
+
+#define DEFINE_BASIC_TYPE_GET_TYPE(type_name) \
+    static LOG_CONTEXT_PROPERTY_TYPE MU_C2(type_name,_log_context_property_get_type)(void) \
+    { \
+        /* Codes_SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_010: [ LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).get_type shall returns the property type LOG_CONTEXT_PROPERTY_TYPE_int64_t. ]*/ \
+        return MU_C2(LOG_CONTEXT_PROPERTY_TYPE_, type_name); \
+    } \
+
+#define DEFINE_BASIC_TYPE_IF(type_name) \
+    const LOG_CONTEXT_PROPERTY_TYPE_IF MU_C2(type_name, _log_context_property_type) = \
+    { \
+        .to_string = MU_C2(type_name, _log_context_property_to_string), \
+        .copy = MU_C2(type_name, _log_context_property_copy), \
+        .free = MU_C2(type_name, _log_context_property_free), \
+        .get_type = MU_C2(type_name, _log_context_property_get_type) \
+    }; \
+
+#define DEFINE_BASIC_TYPE(type_name, print_format_string) \
+    DEFINE_BASIC_TYPE_TO_STRING(type_name, print_format_string) \
+    DEFINE_BASIC_TYPE_COPY(type_name) \
+    DEFINE_BASIC_TYPE_FREE(type_name) \
+    DEFINE_BASIC_TYPE_GET_TYPE(type_name) \
+    DEFINE_BASIC_TYPE_IF(type_name)
+
+DEFINE_BASIC_TYPE(int64_t, PRId64)
+DEFINE_BASIC_TYPE(uint64_t, PRIu64)
+DEFINE_BASIC_TYPE(int32_t, PRId32)
+DEFINE_BASIC_TYPE(uint32_t, PRIu32)
+DEFINE_BASIC_TYPE(int16_t, PRId16)
+DEFINE_BASIC_TYPE(uint16_t, PRIu16)
+DEFINE_BASIC_TYPE(int8_t, PRId8)
+DEFINE_BASIC_TYPE(uint8_t, PRIu8)

--- a/v2/src/log_context_property_basic_types.c
+++ b/v2/src/log_context_property_basic_types.c
@@ -8,6 +8,7 @@
 
 #include "c_logging/log_context_property_type.h"
 #include "c_logging/log_context_property_type_if.h"
+
 #include "c_logging/log_context_property_basic_types.h"
 
 #define DEFINE_BASIC_TYPE_TO_STRING(type_name, print_format_string) \
@@ -84,7 +85,6 @@
     DEFINE_BASIC_TYPE_COPY(type_name) \
     DEFINE_BASIC_TYPE_FREE(type_name) \
     DEFINE_BASIC_TYPE_GET_TYPE(type_name) \
-    DEFINE_BASIC_TYPE_IF(type_name)
 
 DEFINE_BASIC_TYPE(int64_t, PRId64)
 DEFINE_BASIC_TYPE(uint64_t, PRIu64)
@@ -94,3 +94,5 @@ DEFINE_BASIC_TYPE(int16_t, PRId16)
 DEFINE_BASIC_TYPE(uint16_t, PRIu16)
 DEFINE_BASIC_TYPE(int8_t, PRId8)
 DEFINE_BASIC_TYPE(uint8_t, PRIu8)
+
+MU_FOR_EACH_1(DEFINE_BASIC_TYPE_IF, SUPPORTED_BASIC_TYPES)

--- a/v2/tests/CMakeLists.txt
+++ b/v2/tests/CMakeLists.txt
@@ -3,6 +3,8 @@
 
 #unit tests
 if(${run_unittests})
+   add_subdirectory(log_context_property_basic_types_ut)
+   add_subdirectory(log_context_property_type_if_ut)
 endif()
 
 if(${run_int_tests})

--- a/v2/tests/log_context_property_basic_types_ut/CMakeLists.txt
+++ b/v2/tests/log_context_property_basic_types_ut/CMakeLists.txt
@@ -1,0 +1,12 @@
+#Copyright (c) Microsoft. All rights reserved.
+#Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+add_executable(log_context_property_basic_types_ut
+    log_context_property_basic_types_ut.c
+    log_context_property_basic_types_mocked.c
+)
+
+include_directories(../../src)
+target_link_libraries(log_context_property_basic_types_ut c_logging_v2)
+add_test(NAME log_context_property_basic_types_ut COMMAND log_context_property_basic_types_ut)
+set_target_properties(log_context_property_basic_types_ut PROPERTIES FOLDER "tests/c_logging_v2")

--- a/v2/tests/log_context_property_basic_types_ut/log_context_property_basic_types_mocked.c
+++ b/v2/tests/log_context_property_basic_types_ut/log_context_property_basic_types_mocked.c
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include <stdio.h>
+
+#define snprintf mock_snprintf
+
+extern int mock_snprintf(char* s, size_t n, const char* format, ...);
+
+#include "log_context_property_basic_types.c"

--- a/v2/tests/log_context_property_basic_types_ut/log_context_property_basic_types_ut.c
+++ b/v2/tests/log_context_property_basic_types_ut/log_context_property_basic_types_ut.c
@@ -2,8 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #include <stdio.h>
+#include <stdint.h>
 #include <stdbool.h>
 #include <stdarg.h>
+#include <string.h>
+
+#include "macro_utils/macro_utils.h"
 
 #include "c_logging/log_context_property_type.h"
 #include "c_logging/log_context_property_type_if.h"

--- a/v2/tests/log_context_property_basic_types_ut/log_context_property_basic_types_ut.c
+++ b/v2/tests/log_context_property_basic_types_ut/log_context_property_basic_types_ut.c
@@ -1,0 +1,341 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdarg.h>
+
+#include "c_logging/log_context_property_type.h"
+#include "c_logging/log_context_property_type_if.h"
+#include "c_logging/log_context_property_basic_types.h"
+
+static size_t asserts_failed = 0;
+
+// defines how many mock calls we can have
+#define MAX_MOCK_CALL_COUNT (128)
+
+#define MOCK_CALL_TYPE_VALUES \
+    MOCK_CALL_TYPE_snprintf \
+
+MU_DEFINE_ENUM(MOCK_CALL_TYPE, MOCK_CALL_TYPE_VALUES)
+
+// very poor mans mocks :-(
+typedef struct snprintf_CALL_TAG
+{
+    bool override_result;
+    int call_result;
+} snprintf_CALL;
+
+typedef struct MOCK_CALL_TAG
+{
+    MOCK_CALL_TYPE mock_call_type;
+    union
+    {
+        snprintf_CALL snprintf_call;
+    } u;
+} MOCK_CALL;
+
+static MOCK_CALL expected_calls[MAX_MOCK_CALL_COUNT];
+static size_t expected_call_count;
+static size_t actual_call_count;
+static bool actual_and_expected_match;
+
+int mock_snprintf(char* s, size_t n, const char* format, ...)
+{
+    int result;
+
+    if ((actual_call_count == expected_call_count) ||
+        (expected_calls[actual_call_count].mock_call_type != MOCK_CALL_TYPE_snprintf))
+    {
+        actual_and_expected_match = false;
+        return -1;
+    }
+    else
+    {
+        if (expected_calls[actual_call_count].u.snprintf_call.override_result)
+        {
+            result = expected_calls[actual_call_count].u.snprintf_call.call_result;
+        }
+        else
+        {
+            va_list args;
+            va_start(args, format);
+
+            result = vsnprintf(s, n, format, args);
+
+            va_end(args);
+        }
+
+        actual_call_count++;
+    }
+
+    return result;
+}
+
+static void setup_mocks(void)
+{
+    expected_call_count = 0;
+    actual_call_count = 0;
+    actual_and_expected_match = true;
+}
+
+static void setup_expected_snprintf_call(void)
+{
+    expected_calls[0].mock_call_type = MOCK_CALL_TYPE_snprintf;
+    expected_calls[0].u.snprintf_call.override_result = false;
+    expected_call_count = 1;
+}
+
+#define TEST_BUFFER_SIZE 1024
+
+#define POOR_MANS_ASSERT(cond) \
+    if (!(cond)) \
+    { \
+        (void)printf("%s:%d test failed\r\n", __FUNCTION__, __LINE__); \
+        asserts_failed++; \
+    } \
+
+/* LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).to_string */
+
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_001: [ If property_value is NULL, LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).to_string shall fail and return -1. ]*/
+static void int32_t_to_string_with_NULL_value_fails(void)
+{
+    // arrange
+    char buffer[TEST_BUFFER_SIZE];
+    setup_mocks();
+
+    // act
+    int result = LOG_CONTEXT_PROPERTY_TYPE_IMPL(int32_t).to_string(NULL, buffer, TEST_BUFFER_SIZE);
+
+    // assert
+    POOR_MANS_ASSERT(result < 0);
+    POOR_MANS_ASSERT(actual_and_expected_match);
+}
+
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_002: [ LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).to_string shall call snprintf with buffer, buffer_length and format string PRId64 and pass in the values list the int64_t value pointed to be property_value. ]*/
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_003: [ LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).to_string shall succeed and return the result of snprintf. ]*/
+static void int32_t_to_string_succeeds(void)
+{
+    // arrange
+    char buffer[TEST_BUFFER_SIZE];
+    int32_t int32_t_value = 0;
+
+    setup_mocks();
+    setup_expected_snprintf_call();
+
+    // act
+    int result = LOG_CONTEXT_PROPERTY_TYPE_IMPL(int32_t).to_string(&int32_t_value, buffer, TEST_BUFFER_SIZE);
+
+    // assert
+    POOR_MANS_ASSERT(result == 1);
+    POOR_MANS_ASSERT(strcmp(buffer, "0") == 0);
+    POOR_MANS_ASSERT(actual_and_expected_match);
+}
+
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_002: [ LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).to_string shall call snprintf with buffer, buffer_length and format string PRId64 and pass in the values list the int64_t value pointed to be property_value. ]*/
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_003: [ LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).to_string shall succeed and return the result of snprintf. ]*/
+static void int32_t_to_string_INT32_MAX_succeeds(void)
+{
+    // arrange
+    char buffer[TEST_BUFFER_SIZE];
+    int32_t int32_t_value = INT32_MAX;
+
+    setup_mocks();
+    setup_expected_snprintf_call();
+
+    // act
+    int result = LOG_CONTEXT_PROPERTY_TYPE_IMPL(int32_t).to_string(&int32_t_value, buffer, TEST_BUFFER_SIZE);
+
+    // assert
+    POOR_MANS_ASSERT(result == 10);
+    POOR_MANS_ASSERT(strcmp(buffer, "2147483647") == 0);
+    POOR_MANS_ASSERT(actual_and_expected_match);
+}
+
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_002: [ LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).to_string shall call snprintf with buffer, buffer_length and format string PRId64 and pass in the values list the int64_t value pointed to be property_value. ]*/
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_003: [ LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).to_string shall succeed and return the result of snprintf. ]*/
+static void int32_t_to_string_with_truncation_succeeds(void)
+{
+    // arrange
+    char buffer[2];
+    int32_t int32_t_value = 42;
+
+    setup_mocks();
+    setup_expected_snprintf_call();
+
+    // act
+    int result = LOG_CONTEXT_PROPERTY_TYPE_IMPL(int32_t).to_string(&int32_t_value, buffer, 2);
+
+    // assert
+    POOR_MANS_ASSERT(result == 2);
+    POOR_MANS_ASSERT(strcmp(buffer, "4") == 0);
+    POOR_MANS_ASSERT(actual_and_expected_match);
+}
+
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_002: [ LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).to_string shall call snprintf with buffer, buffer_length and format string PRId64 and pass in the values list the int64_t value pointed to be property_value. ]*/
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_003: [ LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).to_string shall succeed and return the result of snprintf. ]*/
+static void int32_t_to_string_with_negative_value_succeeds(void)
+{
+    // arrange
+    char buffer[TEST_BUFFER_SIZE];
+    int32_t int32_t_value = -1;
+
+    setup_mocks();
+    setup_expected_snprintf_call();
+
+    // act
+    int result = LOG_CONTEXT_PROPERTY_TYPE_IMPL(int32_t).to_string(&int32_t_value, buffer, TEST_BUFFER_SIZE);
+
+    // assert
+    POOR_MANS_ASSERT(result > 0);
+    POOR_MANS_ASSERT(strcmp(buffer, "-1") == 0);
+    POOR_MANS_ASSERT(actual_and_expected_match);
+}
+
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_004: [ If any error is encountered, LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).to_string shall fail and return -1. ]*/
+static void when_snprintf_fails_int32_t_to_string_also_fails(void)
+{
+    // arrange
+    char buffer[TEST_BUFFER_SIZE];
+    int32_t int32_t_value = -1;
+
+    setup_mocks();
+    expected_calls[0].mock_call_type = MOCK_CALL_TYPE_snprintf;
+    expected_calls[0].u.snprintf_call.call_result = -1;
+    expected_calls[0].u.snprintf_call.override_result = true;
+    expected_call_count = 1;
+
+    // act
+    int result = LOG_CONTEXT_PROPERTY_TYPE_IMPL(int32_t).to_string(&int32_t_value, buffer, TEST_BUFFER_SIZE);
+
+    // assert
+    POOR_MANS_ASSERT(result < 0);
+    POOR_MANS_ASSERT(actual_and_expected_match);
+}
+
+/* LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).copy */
+
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_005: [ If src_value is NULL, LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).copy shall fail and return a non-zero value. ]*/
+static void int32_t_copy_called_with_NULL_dst_value_fails(void)
+{
+    // arrange
+    int32_t src = 42;
+
+    setup_mocks();
+
+    // act
+    int result = LOG_CONTEXT_PROPERTY_TYPE_IMPL(int32_t).copy(NULL, &src);
+
+    // assert
+    POOR_MANS_ASSERT(result != 0);
+    POOR_MANS_ASSERT(actual_and_expected_match);
+}
+
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_006: [ If dst_value is NULL, LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).copy shall fail and return a non-zero value. ]*/
+static void int32_t_copy_called_with_NULL_src_value_fails(void)
+{
+    // arrange
+    int32_t dst;
+
+    setup_mocks();
+
+    // act
+    int result = LOG_CONTEXT_PROPERTY_TYPE_IMPL(int32_t).copy(&dst, NULL);
+
+    // assert
+    POOR_MANS_ASSERT(result != 0);
+    POOR_MANS_ASSERT(actual_and_expected_match);
+}
+
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_007: [ LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).copy shall copy the bytes of the int64_t value from the address pointed by src_value to dst_value. ]*/
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_008: [ LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).copy shall succeed and return 0. ]*/
+static void int32_t_copy_succeeds(void)
+{
+    // arrange
+    int32_t src = 42;
+    int32_t dst = 43;
+
+    setup_mocks();
+
+    // act
+    int result = LOG_CONTEXT_PROPERTY_TYPE_IMPL(int32_t).copy(&dst, &src);
+
+    // assert
+    POOR_MANS_ASSERT(result == 0);
+    POOR_MANS_ASSERT(dst == 42);
+    POOR_MANS_ASSERT(actual_and_expected_match);
+}
+
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_007: [ LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).copy shall copy the bytes of the int64_t value from the address pointed by src_value to dst_value. ]*/
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_008: [ LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).copy shall succeed and return 0. ]*/
+static void int32_t_copy_succeeds_2(void)
+{
+    // arrange
+    int32_t src = INT32_MAX;
+    int32_t dst = 43;
+
+    setup_mocks();
+
+    // act
+    int result = LOG_CONTEXT_PROPERTY_TYPE_IMPL(int32_t).copy(&dst, &src);
+
+    // assert
+    POOR_MANS_ASSERT(result == 0);
+    POOR_MANS_ASSERT(dst == INT32_MAX);
+    POOR_MANS_ASSERT(actual_and_expected_match);
+}
+
+/* LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).free */
+
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_009: [ LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).free shall return. ]*/
+static void int32_t_free_returns(void)
+{
+    // arrange
+    int32_t value = INT32_MAX;
+
+    setup_mocks();
+
+    // act
+    LOG_CONTEXT_PROPERTY_TYPE_IMPL(int32_t).free(&value);
+
+    // assert
+    POOR_MANS_ASSERT(actual_and_expected_match);
+}
+
+/* LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).get_type */
+
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_BASIC_TYPES_01_010: [ LOG_CONTEXT_PROPERTY_TYPE_IMPL(int64_t).get_type shall returns the property type LOG_CONTEXT_PROPERTY_TYPE_int64_t. ]*/
+static void int32_t_get_type_returns_LOG_CONTEXT_PROPERTY_TYPE_int64_t(void)
+{
+    // arrange
+    setup_mocks();
+
+    // act
+    LOG_CONTEXT_PROPERTY_TYPE result = LOG_CONTEXT_PROPERTY_TYPE_IMPL(int32_t).get_type();
+
+    // assert
+    POOR_MANS_ASSERT(result == LOG_CONTEXT_PROPERTY_TYPE_int32_t);
+    POOR_MANS_ASSERT(actual_and_expected_match);
+}
+
+/* very "poor man's" way of testing, as no test harness and mocking framework are available */
+int main(void)
+{
+    int32_t_to_string_with_NULL_value_fails();
+    int32_t_to_string_succeeds();
+    int32_t_to_string_INT32_MAX_succeeds();
+    int32_t_to_string_with_truncation_succeeds();
+    int32_t_to_string_with_negative_value_succeeds();
+    when_snprintf_fails_int32_t_to_string_also_fails();
+
+    int32_t_copy_called_with_NULL_dst_value_fails();
+    int32_t_copy_called_with_NULL_src_value_fails();
+    int32_t_copy_succeeds();
+    int32_t_copy_succeeds_2();
+
+    int32_t_free_returns();
+
+    int32_t_get_type_returns_LOG_CONTEXT_PROPERTY_TYPE_int64_t();
+
+    return asserts_failed;
+}

--- a/v2/tests/log_context_property_type_if_ut/CMakeLists.txt
+++ b/v2/tests/log_context_property_type_if_ut/CMakeLists.txt
@@ -1,0 +1,11 @@
+#Copyright (c) Microsoft. All rights reserved.
+#Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+add_executable(log_context_property_type_if_ut
+    log_context_property_type_if_ut.c
+)
+
+include_directories(../../src)
+target_link_libraries(log_context_property_type_if_ut c_logging_v2)
+add_test(NAME log_context_property_type_if_ut COMMAND log_context_property_type_if_ut)
+set_target_properties(log_context_property_type_if_ut PROPERTIES FOLDER "tests/c_logging_v2")

--- a/v2/tests/log_context_property_type_if_ut/log_context_property_type_if_ut.c
+++ b/v2/tests/log_context_property_type_if_ut/log_context_property_type_if_ut.c
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #include <stdio.h>
+#include <string.h>
 
 #include "macro_utils/macro_utils.h"
 

--- a/v2/tests/log_context_property_type_if_ut/log_context_property_type_if_ut.c
+++ b/v2/tests/log_context_property_type_if_ut/log_context_property_type_if_ut.c
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include <stdio.h>
+
+#include "macro_utils/macro_utils.h"
+
+#include "c_logging/log_context_property_type_if.h"
+
+static size_t asserts_failed = 0;
+
+// defines how many mock calls we can have
+#define MAX_MOCK_CALL_COUNT (128)
+
+#define MOCK_CALL_TYPE_VALUES \
+    MOCK_CALL_TYPE_snprintf \
+
+MU_DEFINE_ENUM(MOCK_CALL_TYPE, MOCK_CALL_TYPE_VALUES)
+
+#define POOR_MANS_ASSERT(cond) \
+    if (!(cond)) \
+    { \
+        (void)printf("%s:%d test failed\r\n", __FUNCTION__, __LINE__); \
+        asserts_failed++; \
+    } \
+
+/* LOG_CONTEXT_PROPERTY_TYPE_IMPL(type_name) */
+
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TYPE_IF_01_001: [ LOG_CONTEXT_PROPERTY_TYPE_IMPL(type_name) shall produce the token {type_name}_log_context_property_type. ]*/
+static void LOG_CONTEXT_PROPERTY_TYPE_IMPL_produces_the_correct_token(void)
+{
+    // arrange
+
+    // act
+    const char* result = MU_TOSTRING(LOG_CONTEXT_PROPERTY_TYPE_IMPL(gogu));
+
+    // assert
+    POOR_MANS_ASSERT(strcmp(result, "gogu_log_context_property_type") == 0);
+}
+
+/* very "poor man's" way of testing, as no test harness and mocking framework are available */
+int main(void)
+{
+    LOG_CONTEXT_PROPERTY_TYPE_IMPL_produces_the_correct_token();
+
+    return asserts_failed;
+}


### PR DESCRIPTION
- Add log_context_property_type_if with 4 functions in it (to_string, copy, free and get_type)
- Add basic types unit where all the integer types will live
- Add implementation and tests for int32_t (the rest will follow by abundant copy/paste)