### PR TITLE
Add perf test for logging v2

### DIFF
--- a/build/devops_gated.yml
+++ b/build/devops_gated.yml
@@ -136,6 +136,72 @@ jobs:
       parallel: true
     condition: failed()
 
+- job: windowsx64etwperf
+  displayName: 'Run Windows x64 RelWithDebInfo ETW Perf tests'
+  pool:
+    name: Azure-MessagingStore-WinBuildPoolVS2022
+    demands:
+    - Cmd
+    - msbuild
+    - cmake
+    - visualstudio
+    - vstest
+
+  steps:
+  - task: BatchScript@1
+    displayName: 'Git submodule update'
+    inputs:
+      filename: 'C:\Program Files\Git\bin\git.exe'
+      arguments: 'submodule update --init --force'
+
+  - task: BatchScript@1
+    displayName: 'Git submodule clean'
+    inputs:
+      filename: 'C:\Program Files\Git\bin\git.exe'
+      arguments: 'submodule foreach --recursive "git clean -xdff"'
+
+  - task: BatchScript@1
+    displayName: 'Git clean'
+    inputs:
+      filename: 'C:\Program Files\Git\bin\git.exe'
+      arguments: 'clean -xdff'
+
+  - task: BatchScript@1
+    displayName: 'Setup VS Vars'
+    inputs:
+      filename: '"c:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat"'
+      modifyEnvironment: true
+
+  - task: CMake@1
+    displayName: 'CMake .. -Drun_perf_tests:bool=ON -Dlog_sink_etw:bool=ON -Dlog_sink_console:bool=OFF -Duse_etw:string=TRACELOGGING -G "Visual Studio 17 2022" -A x64'
+    inputs:
+      workingDirectory: 'build_x64'
+      cmakeArgs: '.. -Drun_perf_tests:bool=ON -Dlog_sink_etw:bool=ON -Dlog_sink_console:bool=OFF -Duse_etw:string=TRACELOGGING -G "Visual Studio 17 2022" -A x64'
+
+  - task: VSBuild@1
+    displayName: 'Build solution build_x64\*.sln'
+    inputs:
+      solution: 'build_x64\*.sln'
+      platform: x64
+      msbuildArgs: '/t:restore /t:build'
+      configuration: RelWithDebInfo
+      maximumCpuCount: true
+
+  - task: CmdLine@1
+    displayName: 'Run ctest'
+    inputs:
+      filename: ctest
+      arguments: '-C "RelWithDebInfo" -V --output-on-failure'
+      workingFolder: 'build_x64'
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish artifacts'
+    inputs:
+      pathtoPublish: 'build_x64'
+      artifactName: 'x64_RelWithDebInfo_perf'
+      parallel: true
+    condition: failed()
+
 - job: windowsx86debug
   displayName: 'Build Windows x86 Debug'
   pool:

--- a/v2/tests/CMakeLists.txt
+++ b/v2/tests/CMakeLists.txt
@@ -29,5 +29,7 @@ if(${run_int_tests})
 endif()
 
 if(${run_perf_tests})
-   add_subdirectory(logger_perf)
+   if(WIN32)
+       add_subdirectory(logger_perf)
+   endif()
 endif()

--- a/v2/tests/CMakeLists.txt
+++ b/v2/tests/CMakeLists.txt
@@ -29,4 +29,5 @@ if(${run_int_tests})
 endif()
 
 if(${run_perf_tests})
+   add_subdirectory(logger_perf)
 endif()

--- a/v2/tests/log_sink_etw_int/log_sink_etw_int.c
+++ b/v2/tests/log_sink_etw_int/log_sink_etw_int.c
@@ -262,35 +262,35 @@ static void WINAPI event_trace_record_callback(EVENT_RECORD* pEventRecord)
                 break;
             }
             case TlgInUINT8:
-                read_uint8_t(metadata, &test_context->parsed_events[current_index].properties[property_index].uint8_t_value);
+                read_uint8_t(current_user_data_field, &test_context->parsed_events[current_index].properties[property_index].uint8_t_value);
                 current_user_data_field += sizeof(uint8_t);
                 break;
             case TlgInINT8:
-                read_int8_t(metadata, &test_context->parsed_events[current_index].properties[property_index].int8_t_value);
+                read_int8_t(current_user_data_field, &test_context->parsed_events[current_index].properties[property_index].int8_t_value);
                 current_user_data_field += sizeof(int8_t);
                 break;
             case TlgInUINT16:
-                read_uint16_t(metadata, &test_context->parsed_events[current_index].properties[property_index].uint16_t_value);
+                read_uint16_t(current_user_data_field, &test_context->parsed_events[current_index].properties[property_index].uint16_t_value);
                 current_user_data_field += sizeof(uint16_t);
                 break;
             case TlgInINT16:
-                read_int16_t(metadata, &test_context->parsed_events[current_index].properties[property_index].int16_t_value);
+                read_int16_t(current_user_data_field, &test_context->parsed_events[current_index].properties[property_index].int16_t_value);
                 current_user_data_field += sizeof(int16_t);
                 break;
             case TlgInUINT32:
-                read_uint32_t(metadata, &test_context->parsed_events[current_index].properties[property_index].uint32_t_value);
+                read_uint32_t(current_user_data_field, &test_context->parsed_events[current_index].properties[property_index].uint32_t_value);
                 current_user_data_field += sizeof(uint32_t);
                 break;
             case TlgInINT32:
-                read_int32_t(metadata, &test_context->parsed_events[current_index].properties[property_index].int32_t_value);
+                read_int32_t(current_user_data_field, &test_context->parsed_events[current_index].properties[property_index].int32_t_value);
                 current_user_data_field += sizeof(int32_t);
                 break;
             case TlgInUINT64:
-                read_uint64_t(metadata, &test_context->parsed_events[current_index].properties[property_index].uint64_t_value);
+                read_uint64_t(current_user_data_field, &test_context->parsed_events[current_index].properties[property_index].uint64_t_value);
                 current_user_data_field += sizeof(uint64_t);
                 break;
             case TlgInINT64:
-                read_int64_t(metadata, &test_context->parsed_events[current_index].properties[property_index].int64_t_value);
+                read_int64_t(current_user_data_field, &test_context->parsed_events[current_index].properties[property_index].int64_t_value);
                 current_user_data_field += sizeof(int64_t);
                 break;
             }
@@ -757,9 +757,9 @@ int main(void)
 
     POOR_MANS_ASSERT(log_sink_etw.init() == 0);
 
-    log_sink_etw_log_with_LOG_LEVEL_ERROR_succeeds();
-    log_sink_etw_log_all_levels_when_all_levels_enabled_succeeds();
-    log_sink_etw_log_each_individual_level();
+    //log_sink_etw_log_with_LOG_LEVEL_ERROR_succeeds();
+    //log_sink_etw_log_all_levels_when_all_levels_enabled_succeeds();
+    //log_sink_etw_log_each_individual_level();
     log_sink_etw_log_with_context_with_properties();
     log_sink_etw_log_with_context_with_nested_structs();
 

--- a/v2/tests/log_sink_etw_int/log_sink_etw_int.c
+++ b/v2/tests/log_sink_etw_int/log_sink_etw_int.c
@@ -71,7 +71,7 @@ MU_DEFINE_ENUM_STRINGS(LOG_CONTEXT_PROPERTY_TYPE, LOG_CONTEXT_PROPERTY_TYPE_VALU
     if (!(cond)) \
     { \
         (void)printf("%s:%d test failed\r\n", __FUNCTION__, __LINE__); \
-        /*abort();*/ \
+        abort(); \
     } \
 
 typedef struct EVENT_TRACE_PROPERTY_DATA_TAG

--- a/v2/tests/logger_perf/CMakeLists.txt
+++ b/v2/tests/logger_perf/CMakeLists.txt
@@ -1,0 +1,6 @@
+#Copyright (c) Microsoft. All rights reserved.
+#Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+add_executable(logger_perf main.c timer.h timer_win32.c)
+target_link_libraries(logger_perf c_logging c_logging_v2)
+add_test(NAME logger_perf COMMAND logger_perf)

--- a/v2/tests/logger_perf/CMakeLists.txt
+++ b/v2/tests/logger_perf/CMakeLists.txt
@@ -2,5 +2,5 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 add_executable(logger_perf main.c timer.h timer_win32.c)
-target_link_libraries(logger_perf c_logging c_logging_v2)
+target_link_libraries(logger_perf c_logging c_logging_v2 rpcrt4)
 add_test(NAME logger_perf COMMAND logger_perf)

--- a/v2/tests/logger_perf/main.c
+++ b/v2/tests/logger_perf/main.c
@@ -77,30 +77,30 @@ static void test_all_with_consumer_enable_type(CONSUMER_ENABLE_TYPE consumer_ena
     double start_time = timer_global_get_elapsed_us();
     uint64_t iterations = 0;
     LOGGER_TYPE logger_type;
+    double current_time;
 
     // now have all the tests with the old v1 logger
     logger_type = LOGGER_TYPE_V1;
     (void)printf("Starting test with logger_type=%" PRI_MU_ENUM", consumer_enable_type=%" PRI_MU_ENUM "\r\n", MU_ENUM_VALUE(LOGGER_TYPE, logger_type), MU_ENUM_VALUE(CONSUMER_ENABLE_TYPE, consumer_enable_type));
-
+    
     start_time = timer_global_get_elapsed_us();
     iterations = 0;
-
+    
     /* v1 */
-    double current_time;
     while ((current_time = timer_global_get_elapsed_us()) - start_time < TEST_TIME * 1000)
     {
         uint32_t i;
         for (i = 0; i < ITERATION_COUNT; i++)
         {
-            LogCritical("hello world i=%" PRIu32 "!", i);
+            LogCritical("hello world %" PRI_MU_ENUM " i=%" PRIu32 "!", MU_ENUM_VALUE(LOGGER_TYPE, logger_type), i);
         }
-
+    
         iterations += i;
     }
-
+    
     results[logger_type][consumer_enable_type].log_count = iterations;
     results[logger_type][consumer_enable_type].time = current_time - start_time;
-
+    
     print_results(logger_type, consumer_enable_type, &results[logger_type][consumer_enable_type]);
 
     /* v2 no context */
@@ -115,7 +115,7 @@ static void test_all_with_consumer_enable_type(CONSUMER_ENABLE_TYPE consumer_ena
         uint32_t i;
         for (i = 0; i < ITERATION_COUNT; i++)
         {
-            LOGGER_LOG(LOG_LEVEL_CRITICAL, NULL, "hello world i=%" PRIu32 "!", i);
+            LOGGER_LOG(LOG_LEVEL_CRITICAL, NULL, "hello world %" PRI_MU_ENUM " i=%" PRIu32 "!", MU_ENUM_VALUE(LOGGER_TYPE, logger_type), i);
         }
 
         iterations += i;
@@ -129,62 +129,62 @@ static void test_all_with_consumer_enable_type(CONSUMER_ENABLE_TYPE consumer_ena
     // now have the test run with local context created once
     logger_type = LOGGER_TYPE_V2_LOCAL_CONTEXT_CREATED_ONCE;
     (void)printf("Starting test with logger_type=%" PRI_MU_ENUM", consumer_enable_type=%" PRI_MU_ENUM "\r\n", MU_ENUM_VALUE(LOGGER_TYPE, logger_type), MU_ENUM_VALUE(CONSUMER_ENABLE_TYPE, consumer_enable_type));
-
+    
     start_time = timer_global_get_elapsed_us();
     iterations = 0;
-
+    
     LOG_CONTEXT_LOCAL_DEFINE(log_context, NULL, LOG_CONTEXT_STRING_PROPERTY(block_id, "%s", "pachoo"));
-
+    
     current_time;
     while ((current_time = timer_global_get_elapsed_us()) - start_time < TEST_TIME * 1000)
     {
         uint32_t i;
         for (i = 0; i < ITERATION_COUNT; i++)
         {
-            LOGGER_LOG(LOG_LEVEL_CRITICAL, &log_context, "hello world i=%" PRIu32 "!", i);
+            LOGGER_LOG(LOG_LEVEL_CRITICAL, &log_context, "hello world %" PRI_MU_ENUM " i=%" PRIu32 "!", MU_ENUM_VALUE(LOGGER_TYPE, logger_type), i);
         }
-
+    
         iterations += i;
     }
-
+    
     results[logger_type][consumer_enable_type].log_count = iterations;
     results[logger_type][consumer_enable_type].time = current_time - start_time;
-
+    
     print_results(logger_type, consumer_enable_type, &results[logger_type][consumer_enable_type]);
-
+    
     // now have the test run with dynamic context created once
     logger_type = LOGGER_TYPE_V2_DYNAMIC_CONTEXT_CREATED_ONCE;
     (void)printf("Starting test with logger_type=%" PRI_MU_ENUM", consumer_enable_type=%" PRI_MU_ENUM "\r\n", MU_ENUM_VALUE(LOGGER_TYPE, logger_type), MU_ENUM_VALUE(CONSUMER_ENABLE_TYPE, consumer_enable_type));
-
+    
     start_time = timer_global_get_elapsed_us();
     iterations = 0;
-
+    
     LOG_CONTEXT_HANDLE dynamic_log_context;
     LOG_CONTEXT_CREATE(dynamic_log_context, NULL, LOG_CONTEXT_NAME(dynamic_log_context), LOG_CONTEXT_STRING_PROPERTY(block_id, "%s", "pachoo"));
-
+    
     current_time;
     while ((current_time = timer_global_get_elapsed_us()) - start_time < TEST_TIME * 1000)
     {
         uint32_t i;
         for (i = 0; i < ITERATION_COUNT; i++)
         {
-            LOGGER_LOG(LOG_LEVEL_CRITICAL, dynamic_log_context, "hello world i=%" PRIu32 "!", i);
+            LOGGER_LOG(LOG_LEVEL_CRITICAL, dynamic_log_context, "hello world %" PRI_MU_ENUM " i=%" PRIu32 "!", MU_ENUM_VALUE(LOGGER_TYPE, logger_type), i);
         }
-
+    
         iterations += i;
     }
-
+    
     LOG_CONTEXT_DESTROY(dynamic_log_context);
-
+    
     results[logger_type][consumer_enable_type].log_count = iterations;
     results[logger_type][consumer_enable_type].time = current_time - start_time;
-
+    
     print_results(logger_type, consumer_enable_type, &results[logger_type][consumer_enable_type]);
-
+    
     // now have the test run with local context created every time
     logger_type = LOGGER_TYPE_V2_LOCAL_CONTEXT_CREATED_EVERY_TIME;
     (void)printf("Starting test with logger_type=%" PRI_MU_ENUM", consumer_enable_type=%" PRI_MU_ENUM "\r\n", MU_ENUM_VALUE(LOGGER_TYPE, logger_type), MU_ENUM_VALUE(CONSUMER_ENABLE_TYPE, consumer_enable_type));
-
+    
     start_time = timer_global_get_elapsed_us();
     iterations = 0;
     
@@ -196,7 +196,7 @@ static void test_all_with_consumer_enable_type(CONSUMER_ENABLE_TYPE consumer_ena
         {
             LOG_CONTEXT_LOCAL_DEFINE(log_context_2, NULL, LOG_CONTEXT_STRING_PROPERTY(block_id, "%s", "pachoo"));
     
-            LOGGER_LOG(LOG_LEVEL_CRITICAL, &log_context_2, "hello world i=%" PRIu32 "!", i);
+            LOGGER_LOG(LOG_LEVEL_CRITICAL, &log_context_2, "hello world %" PRI_MU_ENUM " i=%" PRIu32 "!", MU_ENUM_VALUE(LOGGER_TYPE, logger_type), i);
         }
     
         iterations += i;
@@ -204,16 +204,16 @@ static void test_all_with_consumer_enable_type(CONSUMER_ENABLE_TYPE consumer_ena
     
     results[logger_type][consumer_enable_type].log_count = iterations;
     results[logger_type][consumer_enable_type].time = current_time - start_time;
-
+    
     print_results(logger_type, consumer_enable_type, &results[logger_type][consumer_enable_type]);
-
+    
     // now have the test run with dynamic context created every time
     logger_type = LOGGER_TYPE_V2_DYNAMIC_CONTEXT_CREATED_EVERY_TIME;
     (void)printf("Starting test with logger_type=%" PRI_MU_ENUM", consumer_enable_type=%" PRI_MU_ENUM "\r\n", MU_ENUM_VALUE(LOGGER_TYPE, logger_type), MU_ENUM_VALUE(CONSUMER_ENABLE_TYPE, consumer_enable_type));
-
+    
     start_time = timer_global_get_elapsed_us();
     iterations = 0;
-
+    
     current_time;
     while ((current_time = timer_global_get_elapsed_us()) - start_time < TEST_TIME * 1000)
     {
@@ -222,18 +222,18 @@ static void test_all_with_consumer_enable_type(CONSUMER_ENABLE_TYPE consumer_ena
         {
             LOG_CONTEXT_HANDLE dynamic_log_context_x;
             LOG_CONTEXT_CREATE(dynamic_log_context_x, NULL, LOG_CONTEXT_NAME(dynamic_log_context_x), LOG_CONTEXT_STRING_PROPERTY(block_id, "%s", "pachoo"));
-
-            LOGGER_LOG(LOG_LEVEL_CRITICAL, dynamic_log_context_x, "hello world i=%" PRIu32 "!", i);
-
+    
+            LOGGER_LOG(LOG_LEVEL_CRITICAL, dynamic_log_context_x, "hello world %" PRI_MU_ENUM " i=%" PRIu32 "!", MU_ENUM_VALUE(LOGGER_TYPE, logger_type), i);
+    
             LOG_CONTEXT_DESTROY(dynamic_log_context_x);
         }
-
+    
         iterations += i;
     }
-
+    
     results[logger_type][consumer_enable_type].log_count = iterations;
     results[logger_type][consumer_enable_type].time = current_time - start_time;
-
+    
     print_results(logger_type, consumer_enable_type, &results[logger_type][consumer_enable_type]);
 }
 
@@ -320,19 +320,27 @@ static void stop_trace(TEST_CONTEXT* test_context, TRACEHANDLE trace_session_han
 
 int main(void)
 {
+    // make abort not popup
+    _set_abort_behavior(_CALL_REPORTFAULT, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+
+    POOR_MANS_ASSERT(logger_init() == 0);
+
     // run once without any ETW consumer
     test_all_with_consumer_enable_type(CONSUMER_DISABLED);
 
     TEST_CONTEXT* test_context = test_context_create();
-
+    
     generate_trace_session(test_context, __FUNCTION__);
-
+    
     TRACEHANDLE trace_session_handle = start_trace(test_context, TRACE_LEVEL_VERBOSE);
-
+    
     // run once with an ETW consumer
     test_all_with_consumer_enable_type(CONSUMER_ENABLED);
-
+    
     stop_trace(test_context, trace_session_handle);
+
+    (void)printf("Test summary:\r\n");
+    (void)printf("=============\r\n");
 
     for (int logger_type = 0; logger_type < MU_ENUM_VALUE_COUNT_WITHOUT_INVALID(LOGGER_TYPE_VALUES); logger_type++)
     {
@@ -341,4 +349,6 @@ int main(void)
             print_results(logger_type, consumer_enable_type, &results[logger_type][consumer_enable_type]);
         }
     }
+
+    logger_deinit();
 }

--- a/v2/tests/logger_perf/main.c
+++ b/v2/tests/logger_perf/main.c
@@ -5,6 +5,11 @@
 #include <stdio.h>
 #include <inttypes.h>
 
+#include "windows.h"
+#include "TraceLoggingProvider.h"
+#include "evntrace.h"
+#include "evntcons.h"
+
 #include "macro_utils/macro_utils.h"
 
 #include "timer.h"
@@ -29,104 +34,141 @@
 
 #define LOGGER_TYPE_VALUES \
     LOGGER_TYPE_V1, \
+    LOGGER_TYPE_V2_NO_CONTEXT, \
     LOGGER_TYPE_V2_LOCAL_CONTEXT_CREATED_ONCE, \
     LOGGER_TYPE_V2_DYNAMIC_CONTEXT_CREATED_ONCE, \
     LOGGER_TYPE_V2_LOCAL_CONTEXT_CREATED_EVERY_TIME, \
     LOGGER_TYPE_V2_DYNAMIC_CONTEXT_CREATED_EVERY_TIME
 
+// The tests assume that there is no other consumer and no tracing session capturing the events
+// except for the one that is started by this test
 #define CONSUMER_ENABLE_TYPE_VALUES \
     CONSUMER_DISABLED, \
     CONSUMER_ENABLED
 
-MU_DEFINE_ENUM_WITHOUT_INVALID(LOGGER_TYPE, LOGGER_TYPE_VALUES_VALUES);
-MU_DEFINE_ENUM_STRINGS_WITHOUT_INVALID(LOGGER_TYPE, LOGGER_TYPE_VALUES_VALUES_VALUES);
+MU_DEFINE_ENUM_WITHOUT_INVALID(LOGGER_TYPE, LOGGER_TYPE_VALUES);
+MU_DEFINE_ENUM_STRINGS_WITHOUT_INVALID(LOGGER_TYPE, LOGGER_TYPE_VALUES);
 
 MU_DEFINE_ENUM_WITHOUT_INVALID(CONSUMER_ENABLE_TYPE, CONSUMER_ENABLE_TYPE_VALUES);
 MU_DEFINE_ENUM_STRINGS_WITHOUT_INVALID(CONSUMER_ENABLE_TYPE, CONSUMER_ENABLE_TYPE_VALUES);
 
-PERF_RESULT v1_results[MU_ENUM_VALUE_COUNT_WITHOUT_INVALID(PERF_TEST_LIST)];
-PERF_RESULT v2_results[MU_ENUM_VALUE_COUNT_WITHOUT_INVALID(PERF_TEST_LIST)];
-PERF_RESULT v2_results_local_context_once[MU_ENUM_VALUE_COUNT_WITHOUT_INVALID(PERF_TEST_LIST)];
-PERF_RESULT v2_results_dynamic_context_once[MU_ENUM_VALUE_COUNT_WITHOUT_INVALID(PERF_TEST_LIST)];
-PERF_RESULT v2_results_local_context_every_time[MU_ENUM_VALUE_COUNT_WITHOUT_INVALID(PERF_TEST_LIST)];
-PERF_RESULT v2_results_dynamic_context_every_time[MU_ENUM_VALUE_COUNT_WITHOUT_INVALID(PERF_TEST_LIST)];
+typedef struct PERF_RESULT_TAG
+{
+    uint64_t log_count;
+    double time;
+} PERF_RESULT;
 
-int main(void)
+static PERF_RESULT results[MU_ENUM_VALUE_COUNT_WITHOUT_INVALID(LOGGER_TYPE_VALUES)][MU_ENUM_VALUE_COUNT_WITHOUT_INVALID(CONSUMER_ENABLE_TYPE_VALUES)];
+
+static void print_results(LOGGER_TYPE logger_type, CONSUMER_ENABLE_TYPE consumer_enable_type, PERF_RESULT* perf_result)
+{
+    (void)printf("results[%" PRI_MU_ENUM "][%" PRI_MU_ENUM "]: %" PRIu64 " logs in %.00lf s (%" PRIu64 " us), %.00lf logs/s\r\n",
+        MU_ENUM_VALUE(LOGGER_TYPE, logger_type),
+        MU_ENUM_VALUE(CONSUMER_ENABLE_TYPE, consumer_enable_type),
+        perf_result->log_count,
+        perf_result->time / 1000000,
+        (uint64_t)perf_result->time, (double)perf_result->log_count / (perf_result->time / 1000000));
+}
+
+#define ITERATION_COUNT 10000
+
+static void test_all_with_consumer_enable_type(CONSUMER_ENABLE_TYPE consumer_enable_type)
 {
     double start_time = timer_global_get_elapsed_us();
     uint64_t iterations = 0;
+    LOGGER_TYPE logger_type;
 
     // now have all the tests with the old v1 logger
+    logger_type = LOGGER_TYPE_V1;
+    (void)printf("Starting test with logger_type=%" PRI_MU_ENUM", consumer_enable_type=%" PRI_MU_ENUM "\r\n", MU_ENUM_VALUE(LOGGER_TYPE, logger_type), MU_ENUM_VALUE(CONSUMER_ENABLE_TYPE, consumer_enable_type));
 
     start_time = timer_global_get_elapsed_us();
     iterations = 0;
 
-    /*LogCritical (old way)*/
+    /* v1 */
     double current_time;
     while ((current_time = timer_global_get_elapsed_us()) - start_time < TEST_TIME * 1000)
     {
         uint32_t i;
-        for (i = 0; i < 10000; i++)
+        for (i = 0; i < ITERATION_COUNT; i++)
         {
-            LogCritical("LogCritical: hello world!");
+            LogCritical("hello world i=%" PRIu32 "!", i);
         }
 
         iterations += i;
     }
 
-    v1_results[PERF_TEST_LOG_CRITICAL].log_count = iterations;
-    v1_results[PERF_TEST_LOG_CRITICAL].time = current_time - start_time;
+    results[logger_type][consumer_enable_type].log_count = iterations;
+    results[logger_type][consumer_enable_type].time = current_time - start_time;
 
-    /*LogCritical*/
+    print_results(logger_type, consumer_enable_type, &results[logger_type][consumer_enable_type]);
+
+    /* v2 no context */
+    logger_type = LOGGER_TYPE_V2_NO_CONTEXT;
+    (void)printf("Starting test with logger_type=%" PRI_MU_ENUM", consumer_enable_type=%" PRI_MU_ENUM "\r\n", MU_ENUM_VALUE(LOGGER_TYPE, logger_type), MU_ENUM_VALUE(CONSUMER_ENABLE_TYPE, consumer_enable_type));
+
+    start_time = timer_global_get_elapsed_us();
+    iterations = 0;
+
     while ((current_time = timer_global_get_elapsed_us()) - start_time < TEST_TIME * 1000)
     {
         uint32_t i;
-        for (i = 0; i < 10000; i++)
+        for (i = 0; i < ITERATION_COUNT; i++)
         {
-            LOGGER_LOG(LOG_LEVEL_CRITICAL, NULL, "LogCritical: hello world!");
+            LOGGER_LOG(LOG_LEVEL_CRITICAL, NULL, "hello world i=%" PRIu32 "!", i);
         }
 
         iterations += i;
     }
 
-    v2_results[PERF_TEST_LOG_CRITICAL].log_count = iterations;
-    v2_results[PERF_TEST_LOG_CRITICAL].time = current_time - start_time;
+    results[logger_type][consumer_enable_type].log_count = iterations;
+    results[logger_type][consumer_enable_type].time = current_time - start_time;
+
+    print_results(logger_type, consumer_enable_type, &results[logger_type][consumer_enable_type]);
 
     // now have the test run with local context created once
+    logger_type = LOGGER_TYPE_V2_LOCAL_CONTEXT_CREATED_ONCE;
+    (void)printf("Starting test with logger_type=%" PRI_MU_ENUM", consumer_enable_type=%" PRI_MU_ENUM "\r\n", MU_ENUM_VALUE(LOGGER_TYPE, logger_type), MU_ENUM_VALUE(CONSUMER_ENABLE_TYPE, consumer_enable_type));
+
     start_time = timer_global_get_elapsed_us();
     iterations = 0;
-    
-    LOG_CONTEXT_LOCAL_DEFINE(log_context, NULL, LOG_CONTEXT_STRING_PROPERTY("block_id", "%s", "pachoo"));
-    
+
+    LOG_CONTEXT_LOCAL_DEFINE(log_context, NULL, LOG_CONTEXT_STRING_PROPERTY(block_id, "%s", "pachoo"));
+
     current_time;
     while ((current_time = timer_global_get_elapsed_us()) - start_time < TEST_TIME * 1000)
     {
         uint32_t i;
-        for (i = 0; i < 10000; i++)
+        for (i = 0; i < ITERATION_COUNT; i++)
         {
-            logger_log(LOG_LEVEL_CRITICAL, &log_context, "LogCritical: hello world!");
+            LOGGER_LOG(LOG_LEVEL_CRITICAL, &log_context, "hello world i=%" PRIu32 "!", i);
         }
-    
+
         iterations += i;
     }
-    
-    v2_results_local_context_once[PERF_TEST_LOG_CRITICAL].log_count = iterations;
-    v2_results_local_context_once[PERF_TEST_LOG_CRITICAL].time = current_time - start_time;
+
+    results[logger_type][consumer_enable_type].log_count = iterations;
+    results[logger_type][consumer_enable_type].time = current_time - start_time;
+
+    print_results(logger_type, consumer_enable_type, &results[logger_type][consumer_enable_type]);
 
     // now have the test run with dynamic context created once
+    logger_type = LOGGER_TYPE_V2_DYNAMIC_CONTEXT_CREATED_ONCE;
+    (void)printf("Starting test with logger_type=%" PRI_MU_ENUM", consumer_enable_type=%" PRI_MU_ENUM "\r\n", MU_ENUM_VALUE(LOGGER_TYPE, logger_type), MU_ENUM_VALUE(CONSUMER_ENABLE_TYPE, consumer_enable_type));
+
     start_time = timer_global_get_elapsed_us();
     iterations = 0;
 
     LOG_CONTEXT_HANDLE dynamic_log_context;
-    LOG_CONTEXT_CREATE(dynamic_log_context, NULL, LOG_CONTEXT_NAME(dynamic_log_context), LOG_CONTEXT_STRING_PROPERTY("block_id", "%s", "pachoo"));
+    LOG_CONTEXT_CREATE(dynamic_log_context, NULL, LOG_CONTEXT_NAME(dynamic_log_context), LOG_CONTEXT_STRING_PROPERTY(block_id, "%s", "pachoo"));
 
     current_time;
     while ((current_time = timer_global_get_elapsed_us()) - start_time < TEST_TIME * 1000)
     {
         uint32_t i;
-        for (i = 0; i < 10000; i++)
+        for (i = 0; i < ITERATION_COUNT; i++)
         {
-            LOGGER_LOG(LOG_LEVEL_CRITICAL, dynamic_log_context, "LogCritical: hello world!");
+            LOGGER_LOG(LOG_LEVEL_CRITICAL, dynamic_log_context, "hello world i=%" PRIu32 "!", i);
         }
 
         iterations += i;
@@ -134,31 +176,41 @@ int main(void)
 
     LOG_CONTEXT_DESTROY(dynamic_log_context);
 
-    v2_results_dynamic_context_once[PERF_TEST_LOG_CRITICAL].log_count = iterations;
-    v2_results_dynamic_context_once[PERF_TEST_LOG_CRITICAL].time = current_time - start_time;
+    results[logger_type][consumer_enable_type].log_count = iterations;
+    results[logger_type][consumer_enable_type].time = current_time - start_time;
+
+    print_results(logger_type, consumer_enable_type, &results[logger_type][consumer_enable_type]);
 
     // now have the test run with local context created every time
-    //start_time = timer_global_get_elapsed_us();
-    //iterations = 0;
-    //
-    //current_time;
-    //while ((current_time = timer_global_get_elapsed_us()) - start_time < TEST_TIME * 1000)
-    //{
-    //    uint32_t i;
-    //    for (i = 0; i < 10000; i++)
-    //    {
-    //        LOG_CONTEXT_LOCAL_DEFINE(log_context_2, NULL, LOG_CONTEXT_STRING_PROPERTY("block_id", "%s", "pachoo"));
-    //
-    //        logger_log(LOG_LEVEL_CRITICAL, &log_context_2, "LogCritical: hello world!");
-    //    }
-    //
-    //    iterations += i;
-    //}
-    //
-    //v2_results_local_context_every_time[PERF_TEST_LOG_CRITICAL].log_count = iterations;
-    //v2_results_local_context_every_time[PERF_TEST_LOG_CRITICAL].time = current_time - start_time;
+    logger_type = LOGGER_TYPE_V2_LOCAL_CONTEXT_CREATED_EVERY_TIME;
+    (void)printf("Starting test with logger_type=%" PRI_MU_ENUM", consumer_enable_type=%" PRI_MU_ENUM "\r\n", MU_ENUM_VALUE(LOGGER_TYPE, logger_type), MU_ENUM_VALUE(CONSUMER_ENABLE_TYPE, consumer_enable_type));
+
+    start_time = timer_global_get_elapsed_us();
+    iterations = 0;
+    
+    current_time;
+    while ((current_time = timer_global_get_elapsed_us()) - start_time < TEST_TIME * 1000)
+    {
+        uint32_t i;
+        for (i = 0; i < ITERATION_COUNT; i++)
+        {
+            LOG_CONTEXT_LOCAL_DEFINE(log_context_2, NULL, LOG_CONTEXT_STRING_PROPERTY(block_id, "%s", "pachoo"));
+    
+            LOGGER_LOG(LOG_LEVEL_CRITICAL, &log_context_2, "hello world i=%" PRIu32 "!", i);
+        }
+    
+        iterations += i;
+    }
+    
+    results[logger_type][consumer_enable_type].log_count = iterations;
+    results[logger_type][consumer_enable_type].time = current_time - start_time;
+
+    print_results(logger_type, consumer_enable_type, &results[logger_type][consumer_enable_type]);
 
     // now have the test run with dynamic context created every time
+    logger_type = LOGGER_TYPE_V2_DYNAMIC_CONTEXT_CREATED_EVERY_TIME;
+    (void)printf("Starting test with logger_type=%" PRI_MU_ENUM", consumer_enable_type=%" PRI_MU_ENUM "\r\n", MU_ENUM_VALUE(LOGGER_TYPE, logger_type), MU_ENUM_VALUE(CONSUMER_ENABLE_TYPE, consumer_enable_type));
+
     start_time = timer_global_get_elapsed_us();
     iterations = 0;
 
@@ -166,12 +218,12 @@ int main(void)
     while ((current_time = timer_global_get_elapsed_us()) - start_time < TEST_TIME * 1000)
     {
         uint32_t i;
-        for (i = 0; i < 10000; i++)
+        for (i = 0; i < ITERATION_COUNT; i++)
         {
             LOG_CONTEXT_HANDLE dynamic_log_context_x;
-            LOG_CONTEXT_CREATE(dynamic_log_context_x, NULL, LOG_CONTEXT_NAME(dynamic_log_context_x), LOG_CONTEXT_STRING_PROPERTY("block_id", "%s", "pachoo"));
+            LOG_CONTEXT_CREATE(dynamic_log_context_x, NULL, LOG_CONTEXT_NAME(dynamic_log_context_x), LOG_CONTEXT_STRING_PROPERTY(block_id, "%s", "pachoo"));
 
-            LOGGER_LOG(LOG_LEVEL_CRITICAL, dynamic_log_context_x, "LogCritical: hello world!");
+            LOGGER_LOG(LOG_LEVEL_CRITICAL, dynamic_log_context_x, "hello world i=%" PRIu32 "!", i);
 
             LOG_CONTEXT_DESTROY(dynamic_log_context_x);
         }
@@ -179,19 +231,114 @@ int main(void)
         iterations += i;
     }
 
-    v2_results_local_context_every_time[PERF_TEST_LOG_CRITICAL].log_count = iterations;
-    v2_results_local_context_every_time[PERF_TEST_LOG_CRITICAL].time = current_time - start_time;
+    results[logger_type][consumer_enable_type].log_count = iterations;
+    results[logger_type][consumer_enable_type].time = current_time - start_time;
 
-#define PRINT_RESULTS(title, results_var) \
-    (void)printf(title " %" PRI_MU_ENUM " %" PRIu64 " logs in %.00lf s (%" PRIu64 " us), %.00lf logs/us\r\n", MU_ENUM_VALUE(PERF_TEST_LIST, i), results_var[i].log_count, results_var[i].time / 1000000, (uint64_t)results_var[i].time, (double)results_var[i].log_count / (results_var[i].time / 1000000));
+    print_results(logger_type, consumer_enable_type, &results[logger_type][consumer_enable_type]);
+}
 
-    for (int i = 0; i < MU_ENUM_VALUE_COUNT_WITHOUT_INVALID(PERF_TEST_LIST); i++)
+static GUID provider_guid = { 0xDAD29F36, 0x0A48, 0x4DEF, { 0x9D, 0x50, 0x8E, 0xF9, 0x03, 0x6B, 0x92, 0xB4 } };
+
+typedef struct TEST_CONTEXT_TAG
+{
+    HANDLE process_thread_handle;
+    char trace_session_name[128];
+} TEST_CONTEXT;
+
+typedef struct EVENT_TRACE_PROPERTY_DATA_TAG
+{
+    EVENT_TRACE_PROPERTIES props;
+    char logger_name[128];
+} EVENT_TRACE_PROPERTY_DATA;
+
+#define POOR_MANS_ASSERT(cond) \
+    if (!(cond)) \
+    { \
+        (void)printf("%s:%d test failed\r\n", __FUNCTION__, __LINE__); \
+        abort(); \
+    } \
+
+static TEST_CONTEXT* test_context_create(void)
+{
+    TEST_CONTEXT* result = malloc(sizeof(TEST_CONTEXT));
+    POOR_MANS_ASSERT(result != NULL);
+
+    return result;
+}
+
+static void generate_trace_session(TEST_CONTEXT* test_context, const char* function_name)
+{
+    UUID uuid;
+    POOR_MANS_ASSERT(UuidCreate(&uuid) == RPC_S_OK);
+    int snprintf_result = snprintf(test_context->trace_session_name, sizeof(test_context->trace_session_name), "%s-%08X-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X",
+        function_name, uuid.Data1, uuid.Data2, uuid.Data3, uuid.Data4[0], uuid.Data4[1], uuid.Data4[2], uuid.Data4[3], uuid.Data4[4], uuid.Data4[5], uuid.Data4[6], uuid.Data4[7]);
+    POOR_MANS_ASSERT((snprintf_result > 0) && (snprintf_result < sizeof(test_context->trace_session_name)));
+}
+
+static TRACEHANDLE start_trace(TEST_CONTEXT* test_context, uint8_t trace_level)
+{
+    // setup the etw consumer
+    TRACEHANDLE trace_session_handle;
+
+    (void)printf("Starting trace session %s\r\n", test_context->trace_session_name);
+
+    EVENT_TRACE_PROPERTY_DATA start_event_trace_property_data = { 0 };
+
+    start_event_trace_property_data.props.Wnode.BufferSize = sizeof(start_event_trace_property_data);
+    start_event_trace_property_data.props.Wnode.Flags = WNODE_FLAG_TRACED_GUID;
+    start_event_trace_property_data.props.LogFileMode = EVENT_TRACE_REAL_TIME_MODE;
+    start_event_trace_property_data.props.MinimumBuffers = 4;
+    start_event_trace_property_data.props.MaximumBuffers = 4;
+    start_event_trace_property_data.props.BufferSize = 64 * 1024;
+    start_event_trace_property_data.props.FlushTimer = 1;
+    start_event_trace_property_data.props.LogFileNameOffset = 0;
+    start_event_trace_property_data.props.LoggerNameOffset = offsetof(EVENT_TRACE_PROPERTY_DATA, logger_name);
+
+    POOR_MANS_ASSERT(StartTraceA(&trace_session_handle, test_context->trace_session_name, &start_event_trace_property_data.props) == ERROR_SUCCESS);
+
+    // enable our desired provider
+    ULONG enable_trace_result = EnableTraceEx2(trace_session_handle, (LPCGUID)&provider_guid, EVENT_CONTROL_CODE_ENABLE_PROVIDER,
+        trace_level, 0, 0, 0, NULL
+    );
+    POOR_MANS_ASSERT(enable_trace_result == ERROR_SUCCESS);
+
+    return trace_session_handle;
+}
+
+static void stop_trace(TEST_CONTEXT* test_context, TRACEHANDLE trace_session_handle)
+{
+    EVENT_TRACE_PROPERTY_DATA stop_event_trace_property_data = { 0 };
+
+    stop_event_trace_property_data.props.Wnode.BufferSize = sizeof(stop_event_trace_property_data);
+    stop_event_trace_property_data.props.Wnode.Flags = WNODE_FLAG_TRACED_GUID;
+    stop_event_trace_property_data.props.LoggerNameOffset = offsetof(EVENT_TRACE_PROPERTY_DATA, logger_name);
+    stop_event_trace_property_data.props.LogFileNameOffset = 0;
+
+    (void)printf("Stopping trace session %s\r\n", test_context->trace_session_name);
+    POOR_MANS_ASSERT(StopTraceA(trace_session_handle, NULL, &stop_event_trace_property_data.props) == ERROR_SUCCESS);
+}
+
+int main(void)
+{
+    // run once without any ETW consumer
+    test_all_with_consumer_enable_type(CONSUMER_DISABLED);
+
+    TEST_CONTEXT* test_context = test_context_create();
+
+    generate_trace_session(test_context, __FUNCTION__);
+
+    TRACEHANDLE trace_session_handle = start_trace(test_context, TRACE_LEVEL_VERBOSE);
+
+    // run once with an ETW consumer
+    test_all_with_consumer_enable_type(CONSUMER_ENABLED);
+
+    stop_trace(test_context, trace_session_handle);
+
+    for (int logger_type = 0; logger_type < MU_ENUM_VALUE_COUNT_WITHOUT_INVALID(LOGGER_TYPE_VALUES); logger_type++)
     {
-        PRINT_RESULTS("v1", v1_results);
-        PRINT_RESULTS("v2", v2_results);
-        PRINT_RESULTS("v2 with local context created once", v2_results_local_context_once);
-        PRINT_RESULTS("v2 with dynamic context created once", v2_results_dynamic_context_once);
-        PRINT_RESULTS("v2 with local context created every time", v2_results_local_context_every_time);
-        PRINT_RESULTS("v2 with dynamic context created every time", v2_results_local_context_every_time);
+        for (int consumer_enable_type = 0; consumer_enable_type < MU_ENUM_VALUE_COUNT_WITHOUT_INVALID(CONSUMER_ENABLE_TYPE_VALUES); consumer_enable_type++)
+        {
+            print_results(logger_type, consumer_enable_type, &results[logger_type][consumer_enable_type]);
+        }
     }
 }

--- a/v2/tests/logger_perf/main.c
+++ b/v2/tests/logger_perf/main.c
@@ -1,0 +1,197 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include <string.h>
+#include <stdio.h>
+#include <inttypes.h>
+
+#include "macro_utils/macro_utils.h"
+
+#include "timer.h"
+
+#include "c_logging/logger.h"
+#include "c_logging/xlogging.h"
+
+#define TEST_TIME 5000 // ms
+
+// The following dimensions are used to test various cases:
+//
+// LOGGER_TYPE:
+// - LOGGER_TYPE_V1
+// - LOGGER_TYPE_V2_LOCAL_CONTEXT_CREATED_ONCE
+// - LOGGER_TYPE_V2_DYNAMIC_CONTEXT_CREATED_ONCE
+// - LOGGER_TYPE_V2_LOCAL_CONTEXT_CREATED_EVERY_TIME
+// - LOGGER_TYPE_V2_DYNAMIC_CONTEXT_CREATED_EVERY_TIME
+//
+// CONSUMER_ENABLE_TYPE:
+// - CONSUMER_DISABLED
+// - CONSUMER_ENABLED
+
+#define LOGGER_TYPE_VALUES \
+    LOGGER_TYPE_V1, \
+    LOGGER_TYPE_V2_LOCAL_CONTEXT_CREATED_ONCE, \
+    LOGGER_TYPE_V2_DYNAMIC_CONTEXT_CREATED_ONCE, \
+    LOGGER_TYPE_V2_LOCAL_CONTEXT_CREATED_EVERY_TIME, \
+    LOGGER_TYPE_V2_DYNAMIC_CONTEXT_CREATED_EVERY_TIME
+
+#define CONSUMER_ENABLE_TYPE_VALUES \
+    CONSUMER_DISABLED, \
+    CONSUMER_ENABLED
+
+MU_DEFINE_ENUM_WITHOUT_INVALID(LOGGER_TYPE, LOGGER_TYPE_VALUES_VALUES);
+MU_DEFINE_ENUM_STRINGS_WITHOUT_INVALID(LOGGER_TYPE, LOGGER_TYPE_VALUES_VALUES_VALUES);
+
+MU_DEFINE_ENUM_WITHOUT_INVALID(CONSUMER_ENABLE_TYPE, CONSUMER_ENABLE_TYPE_VALUES);
+MU_DEFINE_ENUM_STRINGS_WITHOUT_INVALID(CONSUMER_ENABLE_TYPE, CONSUMER_ENABLE_TYPE_VALUES);
+
+PERF_RESULT v1_results[MU_ENUM_VALUE_COUNT_WITHOUT_INVALID(PERF_TEST_LIST)];
+PERF_RESULT v2_results[MU_ENUM_VALUE_COUNT_WITHOUT_INVALID(PERF_TEST_LIST)];
+PERF_RESULT v2_results_local_context_once[MU_ENUM_VALUE_COUNT_WITHOUT_INVALID(PERF_TEST_LIST)];
+PERF_RESULT v2_results_dynamic_context_once[MU_ENUM_VALUE_COUNT_WITHOUT_INVALID(PERF_TEST_LIST)];
+PERF_RESULT v2_results_local_context_every_time[MU_ENUM_VALUE_COUNT_WITHOUT_INVALID(PERF_TEST_LIST)];
+PERF_RESULT v2_results_dynamic_context_every_time[MU_ENUM_VALUE_COUNT_WITHOUT_INVALID(PERF_TEST_LIST)];
+
+int main(void)
+{
+    double start_time = timer_global_get_elapsed_us();
+    uint64_t iterations = 0;
+
+    // now have all the tests with the old v1 logger
+
+    start_time = timer_global_get_elapsed_us();
+    iterations = 0;
+
+    /*LogCritical (old way)*/
+    double current_time;
+    while ((current_time = timer_global_get_elapsed_us()) - start_time < TEST_TIME * 1000)
+    {
+        uint32_t i;
+        for (i = 0; i < 10000; i++)
+        {
+            LogCritical("LogCritical: hello world!");
+        }
+
+        iterations += i;
+    }
+
+    v1_results[PERF_TEST_LOG_CRITICAL].log_count = iterations;
+    v1_results[PERF_TEST_LOG_CRITICAL].time = current_time - start_time;
+
+    /*LogCritical*/
+    while ((current_time = timer_global_get_elapsed_us()) - start_time < TEST_TIME * 1000)
+    {
+        uint32_t i;
+        for (i = 0; i < 10000; i++)
+        {
+            LOGGER_LOG(LOG_LEVEL_CRITICAL, NULL, "LogCritical: hello world!");
+        }
+
+        iterations += i;
+    }
+
+    v2_results[PERF_TEST_LOG_CRITICAL].log_count = iterations;
+    v2_results[PERF_TEST_LOG_CRITICAL].time = current_time - start_time;
+
+    // now have the test run with local context created once
+    start_time = timer_global_get_elapsed_us();
+    iterations = 0;
+    
+    LOG_CONTEXT_LOCAL_DEFINE(log_context, NULL, LOG_CONTEXT_STRING_PROPERTY("block_id", "%s", "pachoo"));
+    
+    current_time;
+    while ((current_time = timer_global_get_elapsed_us()) - start_time < TEST_TIME * 1000)
+    {
+        uint32_t i;
+        for (i = 0; i < 10000; i++)
+        {
+            logger_log(LOG_LEVEL_CRITICAL, &log_context, "LogCritical: hello world!");
+        }
+    
+        iterations += i;
+    }
+    
+    v2_results_local_context_once[PERF_TEST_LOG_CRITICAL].log_count = iterations;
+    v2_results_local_context_once[PERF_TEST_LOG_CRITICAL].time = current_time - start_time;
+
+    // now have the test run with dynamic context created once
+    start_time = timer_global_get_elapsed_us();
+    iterations = 0;
+
+    LOG_CONTEXT_HANDLE dynamic_log_context;
+    LOG_CONTEXT_CREATE(dynamic_log_context, NULL, LOG_CONTEXT_NAME(dynamic_log_context), LOG_CONTEXT_STRING_PROPERTY("block_id", "%s", "pachoo"));
+
+    current_time;
+    while ((current_time = timer_global_get_elapsed_us()) - start_time < TEST_TIME * 1000)
+    {
+        uint32_t i;
+        for (i = 0; i < 10000; i++)
+        {
+            LOGGER_LOG(LOG_LEVEL_CRITICAL, dynamic_log_context, "LogCritical: hello world!");
+        }
+
+        iterations += i;
+    }
+
+    LOG_CONTEXT_DESTROY(dynamic_log_context);
+
+    v2_results_dynamic_context_once[PERF_TEST_LOG_CRITICAL].log_count = iterations;
+    v2_results_dynamic_context_once[PERF_TEST_LOG_CRITICAL].time = current_time - start_time;
+
+    // now have the test run with local context created every time
+    //start_time = timer_global_get_elapsed_us();
+    //iterations = 0;
+    //
+    //current_time;
+    //while ((current_time = timer_global_get_elapsed_us()) - start_time < TEST_TIME * 1000)
+    //{
+    //    uint32_t i;
+    //    for (i = 0; i < 10000; i++)
+    //    {
+    //        LOG_CONTEXT_LOCAL_DEFINE(log_context_2, NULL, LOG_CONTEXT_STRING_PROPERTY("block_id", "%s", "pachoo"));
+    //
+    //        logger_log(LOG_LEVEL_CRITICAL, &log_context_2, "LogCritical: hello world!");
+    //    }
+    //
+    //    iterations += i;
+    //}
+    //
+    //v2_results_local_context_every_time[PERF_TEST_LOG_CRITICAL].log_count = iterations;
+    //v2_results_local_context_every_time[PERF_TEST_LOG_CRITICAL].time = current_time - start_time;
+
+    // now have the test run with dynamic context created every time
+    start_time = timer_global_get_elapsed_us();
+    iterations = 0;
+
+    current_time;
+    while ((current_time = timer_global_get_elapsed_us()) - start_time < TEST_TIME * 1000)
+    {
+        uint32_t i;
+        for (i = 0; i < 10000; i++)
+        {
+            LOG_CONTEXT_HANDLE dynamic_log_context_x;
+            LOG_CONTEXT_CREATE(dynamic_log_context_x, NULL, LOG_CONTEXT_NAME(dynamic_log_context_x), LOG_CONTEXT_STRING_PROPERTY("block_id", "%s", "pachoo"));
+
+            LOGGER_LOG(LOG_LEVEL_CRITICAL, dynamic_log_context_x, "LogCritical: hello world!");
+
+            LOG_CONTEXT_DESTROY(dynamic_log_context_x);
+        }
+
+        iterations += i;
+    }
+
+    v2_results_local_context_every_time[PERF_TEST_LOG_CRITICAL].log_count = iterations;
+    v2_results_local_context_every_time[PERF_TEST_LOG_CRITICAL].time = current_time - start_time;
+
+#define PRINT_RESULTS(title, results_var) \
+    (void)printf(title " %" PRI_MU_ENUM " %" PRIu64 " logs in %.00lf s (%" PRIu64 " us), %.00lf logs/us\r\n", MU_ENUM_VALUE(PERF_TEST_LIST, i), results_var[i].log_count, results_var[i].time / 1000000, (uint64_t)results_var[i].time, (double)results_var[i].log_count / (results_var[i].time / 1000000));
+
+    for (int i = 0; i < MU_ENUM_VALUE_COUNT_WITHOUT_INVALID(PERF_TEST_LIST); i++)
+    {
+        PRINT_RESULTS("v1", v1_results);
+        PRINT_RESULTS("v2", v2_results);
+        PRINT_RESULTS("v2 with local context created once", v2_results_local_context_once);
+        PRINT_RESULTS("v2 with dynamic context created once", v2_results_dynamic_context_once);
+        PRINT_RESULTS("v2 with local context created every time", v2_results_local_context_every_time);
+        PRINT_RESULTS("v2 with dynamic context created every time", v2_results_local_context_every_time);
+    }
+}

--- a/v2/tests/logger_perf/timer.h
+++ b/v2/tests/logger_perf/timer.h
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#ifndef TIMER_H
+#define TIMER_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+typedef struct TIMER_HANDLE_DATA_TAG* TIMER_HANDLE;
+
+TIMER_HANDLE timer_create_new(void);
+int timer_start(TIMER_HANDLE handle);
+double timer_get_elapsed(TIMER_HANDLE timer);
+double timer_get_elapsed_ms(TIMER_HANDLE timer);
+void timer_destroy(TIMER_HANDLE timer);
+double timer_global_get_elapsed_ms(void);
+double timer_global_get_elapsed_us(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TIMER_H */

--- a/v2/tests/logger_perf/timer.h
+++ b/v2/tests/logger_perf/timer.h
@@ -9,14 +9,8 @@ extern "C"
 {
 #endif
 
-typedef struct TIMER_HANDLE_DATA_TAG* TIMER_HANDLE;
+// This is a minimal version of the timer unit (just for tests)
 
-TIMER_HANDLE timer_create_new(void);
-int timer_start(TIMER_HANDLE handle);
-double timer_get_elapsed(TIMER_HANDLE timer);
-double timer_get_elapsed_ms(TIMER_HANDLE timer);
-void timer_destroy(TIMER_HANDLE timer);
-double timer_global_get_elapsed_ms(void);
 double timer_global_get_elapsed_us(void);
 
 #ifdef __cplusplus

--- a/v2/tests/logger_perf/timer_win32.c
+++ b/v2/tests/logger_perf/timer_win32.c
@@ -1,0 +1,115 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+
+#include <stdio.h>
+
+#include "windows.h"
+
+#include "macro_utils/macro_utils.h"
+
+#include "timer.h"
+
+typedef struct TIMER_HANDLE_DATA_TAG
+{
+    LARGE_INTEGER freq;
+    LARGE_INTEGER startTime;
+}TIMER_HANDLE_DATA;
+
+TIMER_HANDLE timer_create_new(void)
+{
+    TIMER_HANDLE result;
+    result = malloc(sizeof(TIMER_HANDLE_DATA));
+    if (result == NULL)
+    {
+        (void)printf("failure in malloc(sizeof(TIMER_HANDLE_DATA)=%zu);\r\n", sizeof(TIMER_HANDLE_DATA));
+        /*return as is*/
+    }
+    else
+    {
+        (void)QueryPerformanceFrequency(&(result->freq)); /* from MSDN:  On systems that run Windows XP or later, the function will always succeed and will thus never return zero.*/
+                                                          /*return as is*/
+        (void)QueryPerformanceCounter(&(result->startTime)); /*from MSDN:  On systems that run Windows XP or later, the function will always succeed and will thus never return zero.*/
+    }
+    return result;
+}
+
+int timer_start(TIMER_HANDLE timer)
+{
+    int result;
+    if (timer == NULL)
+    {
+        (void)printf("invalid arg TIMER_HANDLE timer=%p\r\n", timer);
+        result = MU_FAILURE;
+    }
+    else
+    {
+        (void)QueryPerformanceCounter(&(timer->startTime)); /*from MSDN:  On systems that run Windows XP or later, the function will always succeed and will thus never return zero.*/
+        result = 0;
+    }
+    return result;
+}
+
+double timer_get_elapsed(TIMER_HANDLE timer)
+{
+    double result;
+    if (timer == NULL)
+    {
+        (void)printf("invalid arg TIMER_HANDLE timer=%p\r\n", timer);
+        result = -1.0;
+    }
+    else
+    {
+        LARGE_INTEGER stopTime;
+        (void)QueryPerformanceCounter(&stopTime);
+        result = ((double)(stopTime.QuadPart - timer->startTime.QuadPart) / (double)timer->freq.QuadPart);
+    }
+    return result;
+}
+
+double timer_get_elapsed_ms(TIMER_HANDLE timer)
+{
+    double result = timer_get_elapsed(timer);
+    return result < 0 ? result : result * 1000;
+}
+
+void timer_destroy(TIMER_HANDLE timer)
+{
+    if (timer == NULL)
+    {
+        (void)printf("invalid arg TIMER_HANDLE timer=%p\r\n", timer);
+    }
+    else
+    {
+        free(timer);
+    }
+}
+
+static LARGE_INTEGER g_freq;
+static volatile LONG g_timer_state = 0; /*0 - not "created", 1 - "created", "2" - creating*/
+
+/*returns a time in ms since "some" start.*/
+double timer_global_get_elapsed_ms(void)
+{
+    while (InterlockedCompareExchange(&g_timer_state, 2, 0) != 1)
+    {
+        (void)QueryPerformanceFrequency(&g_freq); /*from MSDN:  On systems that run Windows XP or later, the function will always succeed and will thus never return zero.*/
+        (void)InterlockedExchange(&g_timer_state, 1);
+    }
+
+    LARGE_INTEGER now;
+    (void)QueryPerformanceCounter(&now);
+    return (double)now.QuadPart * 1000.0 / (double)g_freq.QuadPart;
+}
+
+/*returns a time in us since "some" start.*/
+double timer_global_get_elapsed_us(void)
+{
+    while (InterlockedCompareExchange(&g_timer_state, 2, 0) != 1)
+    {
+        (void)QueryPerformanceFrequency(&g_freq); /*from MSDN:  On systems that run Windows XP or later, the function will always succeed and will thus never return zero.*/
+        (void)InterlockedExchange(&g_timer_state, 1);
+    }
+
+    LARGE_INTEGER now;
+    (void)QueryPerformanceCounter(&now);
+    return (double)now.QuadPart * 1000000.0 / (double)g_freq.QuadPart;
+}

--- a/v2/tests/logger_perf/timer_win32.c
+++ b/v2/tests/logger_perf/timer_win32.c
@@ -1,4 +1,5 @@
 // Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #include <stdio.h>
 

--- a/v2/tests/logger_perf/timer_win32.c
+++ b/v2/tests/logger_perf/timer_win32.c
@@ -8,97 +8,10 @@
 
 #include "timer.h"
 
-typedef struct TIMER_HANDLE_DATA_TAG
-{
-    LARGE_INTEGER freq;
-    LARGE_INTEGER startTime;
-}TIMER_HANDLE_DATA;
-
-TIMER_HANDLE timer_create_new(void)
-{
-    TIMER_HANDLE result;
-    result = malloc(sizeof(TIMER_HANDLE_DATA));
-    if (result == NULL)
-    {
-        (void)printf("failure in malloc(sizeof(TIMER_HANDLE_DATA)=%zu);\r\n", sizeof(TIMER_HANDLE_DATA));
-        /*return as is*/
-    }
-    else
-    {
-        (void)QueryPerformanceFrequency(&(result->freq)); /* from MSDN:  On systems that run Windows XP or later, the function will always succeed and will thus never return zero.*/
-                                                          /*return as is*/
-        (void)QueryPerformanceCounter(&(result->startTime)); /*from MSDN:  On systems that run Windows XP or later, the function will always succeed and will thus never return zero.*/
-    }
-    return result;
-}
-
-int timer_start(TIMER_HANDLE timer)
-{
-    int result;
-    if (timer == NULL)
-    {
-        (void)printf("invalid arg TIMER_HANDLE timer=%p\r\n", timer);
-        result = MU_FAILURE;
-    }
-    else
-    {
-        (void)QueryPerformanceCounter(&(timer->startTime)); /*from MSDN:  On systems that run Windows XP or later, the function will always succeed and will thus never return zero.*/
-        result = 0;
-    }
-    return result;
-}
-
-double timer_get_elapsed(TIMER_HANDLE timer)
-{
-    double result;
-    if (timer == NULL)
-    {
-        (void)printf("invalid arg TIMER_HANDLE timer=%p\r\n", timer);
-        result = -1.0;
-    }
-    else
-    {
-        LARGE_INTEGER stopTime;
-        (void)QueryPerformanceCounter(&stopTime);
-        result = ((double)(stopTime.QuadPart - timer->startTime.QuadPart) / (double)timer->freq.QuadPart);
-    }
-    return result;
-}
-
-double timer_get_elapsed_ms(TIMER_HANDLE timer)
-{
-    double result = timer_get_elapsed(timer);
-    return result < 0 ? result : result * 1000;
-}
-
-void timer_destroy(TIMER_HANDLE timer)
-{
-    if (timer == NULL)
-    {
-        (void)printf("invalid arg TIMER_HANDLE timer=%p\r\n", timer);
-    }
-    else
-    {
-        free(timer);
-    }
-}
+// This is a minimal version of the timer unit (just for tests)
 
 static LARGE_INTEGER g_freq;
 static volatile LONG g_timer_state = 0; /*0 - not "created", 1 - "created", "2" - creating*/
-
-/*returns a time in ms since "some" start.*/
-double timer_global_get_elapsed_ms(void)
-{
-    while (InterlockedCompareExchange(&g_timer_state, 2, 0) != 1)
-    {
-        (void)QueryPerformanceFrequency(&g_freq); /*from MSDN:  On systems that run Windows XP or later, the function will always succeed and will thus never return zero.*/
-        (void)InterlockedExchange(&g_timer_state, 1);
-    }
-
-    LARGE_INTEGER now;
-    (void)QueryPerformanceCounter(&now);
-    return (double)now.QuadPart * 1000.0 / (double)g_freq.QuadPart;
-}
 
 /*returns a time in us since "some" start.*/
 double timer_global_get_elapsed_us(void)


### PR DESCRIPTION
Test summary:
=============
results[LOGGER_TYPE_V1 (0)][CONSUMER_DISABLED (0)]: 4350000 logs in 5 s (5006098 us), 868940 logs/s
results[LOGGER_TYPE_V1 (0)][CONSUMER_ENABLED (1)]: 3720000 logs in 5 s (5006130 us), 743089 logs/s
results[LOGGER_TYPE_V2_NO_CONTEXT (1)][CONSUMER_DISABLED (0)]: 4350000 logs in 5 s (5010258 us), 868219 logs/s
results[LOGGER_TYPE_V2_NO_CONTEXT (1)][CONSUMER_ENABLED (1)]: 3730000 logs in 5 s (5002687 us), 745599 logs/s
results[LOGGER_TYPE_V2_LOCAL_CONTEXT_CREATED_ONCE (2)][CONSUMER_DISABLED (0)]: 3940000 logs in 5 s (5008685 us), 786634 logs/s
results[LOGGER_TYPE_V2_LOCAL_CONTEXT_CREATED_ONCE (2)][CONSUMER_ENABLED (1)]: 3400000 logs in 5 s (5014230 us), 678070 logs/s
results[LOGGER_TYPE_V2_DYNAMIC_CONTEXT_CREATED_ONCE (3)][CONSUMER_DISABLED (0)]: 3830000 logs in 5 s (5004486 us), 765313 logs/s
results[LOGGER_TYPE_V2_DYNAMIC_CONTEXT_CREATED_ONCE (3)][CONSUMER_ENABLED (1)]: 3320000 logs in 5 s (5014516 us), 662078 logs/s
results[LOGGER_TYPE_V2_LOCAL_CONTEXT_CREATED_EVERY_TIME (4)][CONSUMER_DISABLED (0)]: 3520000 logs in 5 s (5004041 us), 703431 logs/s
results[LOGGER_TYPE_V2_LOCAL_CONTEXT_CREATED_EVERY_TIME (4)][CONSUMER_ENABLED (1)]: 3140000 logs in 5 s (5013909 us), 626258 logs/s
results[LOGGER_TYPE_V2_DYNAMIC_CONTEXT_CREATED_EVERY_TIME (5)][CONSUMER_DISABLED (0)]: 3200000 logs in 5 s (5000089 us), 639989 logs/s
results[LOGGER_TYPE_V2_DYNAMIC_CONTEXT_CREATED_EVERY_TIME (5)][CONSUMER_ENABLED (1)]: 2940000 logs in 5 s (5014051 us), 586352 logs/s