### PR TITLE
Fix struct property count for nested structs

### DIFF
--- a/v2/inc/c_logging/log_context.h
+++ b/v2/inc/c_logging/log_context.h
@@ -234,7 +234,7 @@ uint32_t internal_log_context_get_values_data_length_or_zero(LOG_CONTEXT_HANDLE 
             LOG_CONTEXT_PROPERTY_VALUE_PAIR* first_property_value_pair = destination_context.property_value_pairs_ptr; \
             (void)property_value_pair; \
             uint8_t* data_pos = destination_context.values_data; \
-            *data_pos = (uint8_t)(log_context_get_property_value_pair_count(parent_context) MU_IF(MU_COUNT_ARG(__VA_ARGS__), MU_FOR_EACH_1(COUNT_PROPERTY, __VA_ARGS__),)); \
+            *data_pos = (uint8_t)((parent_context != NULL ? 1 : 0) MU_IF(MU_COUNT_ARG(__VA_ARGS__), MU_FOR_EACH_1(COUNT_PROPERTY, __VA_ARGS__),)); \
             /* Codes_SRS_LOG_CONTEXT_01_015: [ LOG_CONTEXT_LOCAL_DEFINE shall store one property/value pair that with a property type of struct with as many fields as the total number of properties passed to LOG_CONTEXT_LOCAL_DEFINE in the ... arguments. ]*/ \
             first_property_value_pair->value = data_pos; \
             first_property_value_pair->name = ""; \
@@ -260,7 +260,7 @@ void log_context_destroy(LOG_CONTEXT_HANDLE log_context);
             LOG_CONTEXT_PROPERTY_VALUE_PAIR* first_property_value_pair = destination_context->property_value_pairs_ptr; \
             (void)property_value_pair; \
             uint8_t* data_pos = destination_context->values_data; \
-            *data_pos = (uint8_t)(log_context_get_property_value_pair_count(parent_context) MU_IF(MU_COUNT_ARG(__VA_ARGS__), MU_FOR_EACH_1(COUNT_PROPERTY, __VA_ARGS__),)); \
+            *data_pos = (uint8_t)((parent_context != NULL ? 1 : 0) MU_IF(MU_COUNT_ARG(__VA_ARGS__), MU_FOR_EACH_1(COUNT_PROPERTY, __VA_ARGS__),)); \
             /* Codes_SRS_LOG_CONTEXT_01_013: [ LOG_CONTEXT_CREATE shall store one property/value pair that with a property type of struct with as many fields as the total number of properties passed to LOG_CONTEXT_CREATE. ]*/ \
             first_property_value_pair->value = data_pos; \
             /* Codes_SRS_LOG_CONTEXT_01_009: [ LOG_CONTEXT_NAME shall be optional. ]*/ \

--- a/v2/tests/log_context_ut/log_context_ut.c
+++ b/v2/tests/log_context_ut/log_context_ut.c
@@ -1115,7 +1115,7 @@ static void LOG_CONTEXT_CREATE_with_a_parent_that_has_one_int_property_succeeds(
     POOR_MANS_ASSERT(log_context_get_property_value_pair_count(result) == 3);
     const LOG_CONTEXT_PROPERTY_VALUE_PAIR* pairs = log_context_get_property_value_pairs(result);
     // context struct
-    POOR_MANS_ASSERT(*(uint8_t*)pairs[0].value == 2);
+    POOR_MANS_ASSERT(*(uint8_t*)pairs[0].value == 1);
     POOR_MANS_ASSERT(strcmp(pairs[0].name, "") == 0);
     POOR_MANS_ASSERT(pairs[0].type->get_type() == LOG_CONTEXT_PROPERTY_TYPE_struct);
     // parent context struct
@@ -1153,7 +1153,7 @@ static void LOG_CONTEXT_CREATE_with_a_parent_that_has_2_int_properties_succeeds(
     POOR_MANS_ASSERT(log_context_get_property_value_pair_count(result) == 4);
     const LOG_CONTEXT_PROPERTY_VALUE_PAIR* pairs = log_context_get_property_value_pairs(result);
     // context struct
-    POOR_MANS_ASSERT(*(uint8_t*)pairs[0].value == 3);
+    POOR_MANS_ASSERT(*(uint8_t*)pairs[0].value == 1);
     POOR_MANS_ASSERT(strcmp(pairs[0].name, "") == 0);
     POOR_MANS_ASSERT(pairs[0].type->get_type() == LOG_CONTEXT_PROPERTY_TYPE_struct);
     // parent context struct
@@ -1195,7 +1195,7 @@ static void LOG_CONTEXT_CREATE_with_a_parent_that_has_a_string_property_succeeds
     POOR_MANS_ASSERT(log_context_get_property_value_pair_count(result) == 3);
     const LOG_CONTEXT_PROPERTY_VALUE_PAIR* pairs = log_context_get_property_value_pairs(result);
     // context struct
-    POOR_MANS_ASSERT(*(uint8_t*)pairs[0].value == 2);
+    POOR_MANS_ASSERT(*(uint8_t*)pairs[0].value == 1);
     POOR_MANS_ASSERT(strcmp(pairs[0].name, "") == 0);
     POOR_MANS_ASSERT(pairs[0].type->get_type() == LOG_CONTEXT_PROPERTY_TYPE_struct);
     // parent context struct
@@ -1233,7 +1233,7 @@ static void LOG_CONTEXT_CREATE_with_a_parent_that_has_2_string_properties_succee
     POOR_MANS_ASSERT(log_context_get_property_value_pair_count(result) == 4);
     const LOG_CONTEXT_PROPERTY_VALUE_PAIR* pairs = log_context_get_property_value_pairs(result);
     // context struct
-    POOR_MANS_ASSERT(*(uint8_t*)pairs[0].value == 3);
+    POOR_MANS_ASSERT(*(uint8_t*)pairs[0].value == 1);
     POOR_MANS_ASSERT(strcmp(pairs[0].name, "") == 0);
     POOR_MANS_ASSERT(pairs[0].type->get_type() == LOG_CONTEXT_PROPERTY_TYPE_struct);
     // parent context struct
@@ -1275,7 +1275,7 @@ static void LOG_CONTEXT_CREATE_with_a_parent_that_has_a_context_name_succeeds(vo
     POOR_MANS_ASSERT(log_context_get_property_value_pair_count(result) == 6);
     const LOG_CONTEXT_PROPERTY_VALUE_PAIR* pairs = log_context_get_property_value_pairs(result);
     // context struct
-    POOR_MANS_ASSERT(*(uint8_t*)pairs[0].value == 5);
+    POOR_MANS_ASSERT(*(uint8_t*)pairs[0].value == 1);
     POOR_MANS_ASSERT(strcmp(pairs[0].name, "") == 0);
     POOR_MANS_ASSERT(pairs[0].type->get_type() == LOG_CONTEXT_PROPERTY_TYPE_struct);
     // parent context struct
@@ -1568,7 +1568,7 @@ static void LOG_CONTEXT_LOCAL_DEFINE_with_a_parent_that_has_one_int_property_suc
     POOR_MANS_ASSERT(log_context_get_property_value_pair_count(&result) == 3);
     const LOG_CONTEXT_PROPERTY_VALUE_PAIR* pairs = log_context_get_property_value_pairs(&result);
     // context struct
-    POOR_MANS_ASSERT(*(uint8_t*)pairs[0].value == 2);
+    POOR_MANS_ASSERT(*(uint8_t*)pairs[0].value == 1);
     POOR_MANS_ASSERT(strcmp(pairs[0].name, "") == 0);
     POOR_MANS_ASSERT(pairs[0].type->get_type() == LOG_CONTEXT_PROPERTY_TYPE_struct);
     // parent context struct
@@ -1601,7 +1601,7 @@ static void LOG_CONTEXT_LOCAL_DEFINE_with_a_parent_that_has_2_int_properties_suc
     POOR_MANS_ASSERT(log_context_get_property_value_pair_count(&result) == 4);
     const LOG_CONTEXT_PROPERTY_VALUE_PAIR* pairs = log_context_get_property_value_pairs(&result);
     // context struct
-    POOR_MANS_ASSERT(*(uint8_t*)pairs[0].value == 3);
+    POOR_MANS_ASSERT(*(uint8_t*)pairs[0].value == 1);
     POOR_MANS_ASSERT(strcmp(pairs[0].name, "") == 0);
     POOR_MANS_ASSERT(pairs[0].type->get_type() == LOG_CONTEXT_PROPERTY_TYPE_struct);
     // parent context struct
@@ -1638,7 +1638,7 @@ static void LOG_CONTEXT_LOCAL_DEFINE_with_a_parent_that_has_a_string_property_su
     POOR_MANS_ASSERT(log_context_get_property_value_pair_count(&result) == 3);
     const LOG_CONTEXT_PROPERTY_VALUE_PAIR* pairs = log_context_get_property_value_pairs(&result);
     // context struct
-    POOR_MANS_ASSERT(*(uint8_t*)pairs[0].value == 2);
+    POOR_MANS_ASSERT(*(uint8_t*)pairs[0].value == 1);
     POOR_MANS_ASSERT(strcmp(pairs[0].name, "") == 0);
     POOR_MANS_ASSERT(pairs[0].type->get_type() == LOG_CONTEXT_PROPERTY_TYPE_struct);
     // parent context struct
@@ -1671,7 +1671,7 @@ static void LOG_CONTEXT_LOCAL_DEFINE_with_a_parent_that_has_2_string_properties_
     POOR_MANS_ASSERT(log_context_get_property_value_pair_count(&result) == 4);
     const LOG_CONTEXT_PROPERTY_VALUE_PAIR* pairs = log_context_get_property_value_pairs(&result);
     // context struct
-    POOR_MANS_ASSERT(*(uint8_t*)pairs[0].value == 3);
+    POOR_MANS_ASSERT(*(uint8_t*)pairs[0].value == 1);
     POOR_MANS_ASSERT(strcmp(pairs[0].name, "") == 0);
     POOR_MANS_ASSERT(pairs[0].type->get_type() == LOG_CONTEXT_PROPERTY_TYPE_struct);
     // parent context struct
@@ -1708,7 +1708,7 @@ static void LOG_CONTEXT_LOCAL_DEFINE_with_a_parent_that_has_a_context_name_succe
     POOR_MANS_ASSERT(log_context_get_property_value_pair_count(&result) == 6);
     const LOG_CONTEXT_PROPERTY_VALUE_PAIR* pairs = log_context_get_property_value_pairs(&result);
     // context struct
-    POOR_MANS_ASSERT(*(uint8_t*)pairs[0].value == 5);
+    POOR_MANS_ASSERT(*(uint8_t*)pairs[0].value == 1);
     POOR_MANS_ASSERT(strcmp(pairs[0].name, "") == 0);
     POOR_MANS_ASSERT(pairs[0].type->get_type() == LOG_CONTEXT_PROPERTY_TYPE_struct);
     // parent context struct
@@ -1758,7 +1758,7 @@ static void LOG_CONTEXT_LOCAL_DEFINE_with_a_stack_log_context_succeeds(void)
     POOR_MANS_ASSERT(log_context_get_property_value_pair_count(&local_context_2) == 4);
     const LOG_CONTEXT_PROPERTY_VALUE_PAIR* pairs = log_context_get_property_value_pairs(&local_context_2);
     // context struct
-    POOR_MANS_ASSERT(*(uint8_t*)pairs[0].value == 3);
+    POOR_MANS_ASSERT(*(uint8_t*)pairs[0].value == 2);
     POOR_MANS_ASSERT(strcmp(pairs[0].name, "") == 0);
     POOR_MANS_ASSERT(pairs[0].type->get_type() == LOG_CONTEXT_PROPERTY_TYPE_struct);
     // parent context struct
@@ -1797,7 +1797,7 @@ static void LOG_CONTEXT_CREATE_with_a_stack_log_context_succeeds(void)
     POOR_MANS_ASSERT(log_context_get_property_value_pair_count(context_2) == 4);
     const LOG_CONTEXT_PROPERTY_VALUE_PAIR* pairs = log_context_get_property_value_pairs(context_2);
     // context struct
-    POOR_MANS_ASSERT(*(uint8_t*)pairs[0].value == 3);
+    POOR_MANS_ASSERT(*(uint8_t*)pairs[0].value == 2);
     POOR_MANS_ASSERT(strcmp(pairs[0].name, "") == 0);
     POOR_MANS_ASSERT(pairs[0].type->get_type() == LOG_CONTEXT_PROPERTY_TYPE_struct);
     // parent context struct

--- a/v2/tests/log_sink_etw_int/log_sink_etw_int.c
+++ b/v2/tests/log_sink_etw_int/log_sink_etw_int.c
@@ -770,12 +770,12 @@ static void log_sink_etw_log_with_context_with_nested_structs(void)
 
     POOR_MANS_ASSERT(test_context->parsed_events[0].property_count == 4);
     POOR_MANS_ASSERT(test_context->parsed_events[0].properties[0].property_type == (_TlgInSTRUCT | _TlgInChain));
-    POOR_MANS_ASSERT(test_context->parsed_events[0].properties[0].struct_field_count == 3);
+    POOR_MANS_ASSERT(test_context->parsed_events[0].properties[0].struct_field_count == 2); // First struct is the struct that contains the nested struct and prop2
     POOR_MANS_ASSERT(strcmp(test_context->parsed_events[0].properties[0].property_name, "") == 0);
 
     // log_context_1 properties
     POOR_MANS_ASSERT(test_context->parsed_events[0].properties[1].property_type == (_TlgInSTRUCT | _TlgInChain));
-    POOR_MANS_ASSERT(test_context->parsed_events[0].properties[1].struct_field_count == 1);
+    POOR_MANS_ASSERT(test_context->parsed_events[0].properties[1].struct_field_count == 1); // Second struct is the nested struct that contains only prop1
     POOR_MANS_ASSERT(strcmp(test_context->parsed_events[0].properties[1].property_name, "") == 0);
 
     POOR_MANS_ASSERT(test_context->parsed_events[0].properties[2].property_type == TlgInINT8);

--- a/v2/tests/log_sink_etw_ut/log_sink_etw_ut.c
+++ b/v2/tests/log_sink_etw_ut/log_sink_etw_ut.c
@@ -2971,7 +2971,7 @@ static void when_a_parent_context_is_used_all_properties_are_emitted(void)
     pos += strlen("") + 1;
     *pos = _TlgInSTRUCT | _TlgInChain;
     pos++;
-    *pos = 3;
+    *pos = 2;
     pos++;
 
     // content field for log_context_1


### PR DESCRIPTION
Previously, if we nested multiple structs (multiple nested log contexts), the properties were not parsed correctly when reading the ETW logs.

This fix makes the struct field count correct and updates the console log sink to still produce the correct results.

For example, this code:

```c
    LOG_CONTEXT_HANDLE parent_1;
    LOG_CONTEXT_CREATE(parent_1, NULL, LOG_CONTEXT_NAME(outer), LOG_CONTEXT_PROPERTY(int64_t, instance_id, 0x12345678));

    LOG_CONTEXT_HANDLE parent_2;
    LOG_CONTEXT_CREATE(parent_2, parent_1, LOG_CONTEXT_NAME(middle1), LOG_CONTEXT_PROPERTY(int64_t, a, 0x111));

    LOG_CONTEXT_HANDLE parent_3;
    LOG_CONTEXT_CREATE(parent_3, parent_2, LOG_CONTEXT_NAME(middle2),  LOG_CONTEXT_PROPERTY(int64_t, b, 0x222));

    LOG_CONTEXT_HANDLE child;
    LOG_CONTEXT_CREATE(child, parent_3, LOG_CONTEXT_NAME(child),
        LOG_CONTEXT_STRING_PROPERTY(p1, "foo"),
        LOG_CONTEXT_STRING_PROPERTY(p2, "bar"),
        LOG_CONTEXT_STRING_PROPERTY(p3, "baz"),
        LOG_CONTEXT_STRING_PROPERTY(p4, "x"),
        LOG_CONTEXT_STRING_PROPERTY(p5, "y");

    LOGGER_LOG(LOG_LEVEL_INFO, child, "Logging test with nested contexts");
```

Would previously be parsed in ETW as a json document like this:

```json
{
  "child": {
    "middle2": {
      "middle1": {
        "outer": { 
          "instance_id": 305419896
        },
        "a": 273,
        "b": 546
      },
      "p1": "foo",
      "p2": "bar",
      "p3": "baz",
      "p4": "x"
    },
    "p5": "y"
  }
}
```

This is nested incorrectly, and we should instead expect this (which is what we get with this fix):

```json
{
  "child": {
    "middle2": {
      "middle1": {
        "outer": { 
          "instance_id": 305419896
        },
        "a": 273
      },
      "b": 546
    },
    "p1": "foo",
    "p2": "bar",
    "p3": "baz",
    "p4": "x",
    "p5": "y"
  }
}
```