### PR TITLE
Extract log_context_property_to_string from log_sink_console

### DIFF
--- a/v2/CMakeLists.txt
+++ b/v2/CMakeLists.txt
@@ -26,6 +26,7 @@ set(c_logging_v2_h_files
     ./inc/c_logging/log_context_property_type_if.h
     ./inc/c_logging/log_context_property_basic_types.h
     ./inc/c_logging/log_context_property_bool_type.h
+    ./inc/c_logging/log_context_property_to_string.h
     ./inc/c_logging/log_context_property_type_ascii_char_ptr.h
     ./inc/c_logging/log_context_property_type_struct.h
     ./inc/c_logging/log_context_property_value_pair.h
@@ -42,6 +43,7 @@ set(c_logging_v2_c_files
     ./src/log_context.c
     ./src/log_context_property_basic_types.c
     ./src/log_context_property_bool_type.c
+    ./src/log_context_property_to_string.c
     ./src/log_context_property_type.c
     ./src/log_context_property_type_ascii_char_ptr.c
     ./src/log_context_property_type_struct.c

--- a/v2/devdoc/log_context_property_to_string_requirements.md
+++ b/v2/devdoc/log_context_property_to_string_requirements.md
@@ -1,0 +1,82 @@
+# `log_context_property_to_string` requirements
+
+## Overview
+
+`log_context_property_to_string` is a helper for creating a string from an array of `LOG_CONTEXT_PROPERTY_VALUE_PAIR`. This may be useful for a console sink or another sink that produces a single string with all of the context properties.
+
+## Format
+
+Individual properties are formatted as follows:
+
+```
+ name=value
+```
+
+Structure properties are formatted as follows:
+
+```
+ [struct_name=]{ field1=value, field2=value }
+```
+
+Where the `struct_name` is omitted if the structure is unnamed.
+
+For structure properties, the structure contains a property count, which is the number of fields in the structure. Note that if a structure is nested, then the count does not include the count of properties in the nested structure(s).
+
+For example, the following properties:
+
+- struct name = foo, count = 3
+- struct name = bar, count = 2
+- struct name = baz, count = 2
+- property name = a, value = 1
+- property name = b, value = 2
+- property name = c, value = 3
+- property name = d, value = 4
+- property name = e, value = 5
+
+Will produce the following string with structure nesting:
+
+```
+ foo={ bar={ baz={ a=1, b=2 }, c=3 }, d=4, e=5 }
+```
+
+## Exposed API
+
+```
+int log_context_property_to_string(char* buffer, size_t buffer_size, const LOG_CONTEXT_PROPERTY_VALUE_PAIR* property_value_pairs, size_t property_value_pair_count);
+```
+
+### log_context_property_to_string
+
+```c
+int log_context_property_to_string(char* buffer, size_t buffer_size, const LOG_CONTEXT_PROPERTY_VALUE_PAIR* property_value_pairs, size_t property_value_pair_count);
+```
+
+`log_context_property_to_string` converts all of the property value pairs into a string for printing. Properties of type struct are parsed recursively.
+
+**SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_027: [** If `buffer` is `NULL` then `log_context_property_to_string` shall fail and return a negative value. **]**
+
+**SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_028: [** If `buffer_size` is 0 then `log_context_property_to_string` shall return 0. **]**
+
+**SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_029: [** If `property_value_pairs` is `NULL` then `log_context_property_to_string` shall fail and return a negative value. **]**
+
+**SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_030: [** If `property_value_pair_count` is 0 then `log_context_property_to_string` shall fail and return a negative value. **]**
+
+**SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_016: [** For each property: **]**
+
+ - **SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_017: [** If the property type is `struct` (used as a container for context properties): **]**
+
+   - **SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_025: [** `log_context_property_to_string` shall print the `struct` property name and an opening brace. **]**
+
+   - **SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_018: [** `log_context_property_to_string` shall obtain the number of fields in the `struct`. **]**
+
+   - **SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_019: [** `log_context_property_to_string` shall print the next `n` properties as being the fields that are part of the `struct`. **]**
+
+   - **SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_026: [** `log_context_property_to_string` shall print a closing brace as end of the `struct`. **]**
+
+ - **SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_020: [** Otherwise `log_context_property_to_string` shall call `to_string` for the property and print its name and value. **]**
+
+**SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_021: [** `log_context_property_to_string` shall store at most `buffer_size` characters including the null terminator in `buffer` (the rest of the context shall be truncated). **]**
+
+**SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_022: [** If any encoding error occurs during formatting of the line (i.e. if any `printf` class functions fails), `log_context_property_to_string` shall fail and return a negative value. **]**
+
+**SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_031: [** `log_context_property_to_string` shall return the number of bytes written to the `buffer`. **]**

--- a/v2/devdoc/log_sink_console_requirements.md
+++ b/v2/devdoc/log_sink_console_requirements.md
@@ -68,23 +68,11 @@ typedef void (*LOG_SINK_LOG_FUNC)(LOG_LEVEL log_level, LOG_CONTEXT_HANDLE log_co
 
 **SRS_LOG_SINK_CONSOLE_01_013: [** If `log_context` is non-`NULL`: **]**
 
-  **SRS_LOG_SINK_CONSOLE_01_014: [** `log_sink_console.log` shall call `log_context_get_property_value_pair_count` to obtain the count of properties to print. **]**
+ - **SRS_LOG_SINK_CONSOLE_01_014: [** `log_sink_console.log` shall call `log_context_get_property_value_pair_count` to obtain the count of properties to print. **]**
 
-  **SRS_LOG_SINK_CONSOLE_01_015: [** `log_sink_console.log` shall call `log_context_get_property_value_pairs` to obtain the properties to print. **]**
+ - **SRS_LOG_SINK_CONSOLE_01_015: [** `log_sink_console.log` shall call `log_context_get_property_value_pairs` to obtain the properties to print. **]**
 
-  **SRS_LOG_SINK_CONSOLE_01_016: [** For each property: **]**
-
-   **SRS_LOG_SINK_CONSOLE_01_017: [** If the property type is `struct` (used as a container for context properties): **]**
-
-   **SRS_LOG_SINK_CONSOLE_01_025: [** `log_sink_console.log` shall print the `struct` property name and an opening brace. **]**
-
-   **SRS_LOG_SINK_CONSOLE_01_018: [** `log_sink_console.log` shall obtain the number of fields in the `struct`. **]**
-
-   **SRS_LOG_SINK_CONSOLE_01_019: [** `log_sink_console.log` shall print the next `n` properties as being the fields that are part of the `struct`. **]**
-
-   **SRS_LOG_SINK_CONSOLE_01_026: [** `log_sink_console.log` shall print a closing brace as end of the `struct`. **]**
-
-   **SRS_LOG_SINK_CONSOLE_01_020: [** Otherwise `log_sink_console.log` shall call `to_string` for the property and print its name and value. **]**
+ - **SRS_LOG_SINK_CONSOLE_42_001: [** `log_sink_console.log` shall call `log_context_property_to_string` to print the properties to the string buffer. **]**
 
 **SRS_LOG_SINK_CONSOLE_01_021: [** `log_sink_console.log` shall print at most `LOG_MAX_MESSAGE_LENGTH` characters including the null terminator (the rest of the context shall be truncated). **]**
 

--- a/v2/inc/c_logging/log_context_property_to_string.h
+++ b/v2/inc/c_logging/log_context_property_to_string.h
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#ifndef LOG_CONTEXT_PROPERTY_TO_STRING_H
+#define LOG_CONTEXT_PROPERTY_TO_STRING_H
+
+#ifdef __cplusplus
+#include <cstddef>
+#else
+#include <stddef.h>
+#endif
+
+#include "c_logging/log_context_property_value_pair.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int log_context_property_to_string(char* buffer, size_t buffer_size, const LOG_CONTEXT_PROPERTY_VALUE_PAIR* property_value_pairs, size_t property_value_pair_count);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LOG_CONTEXT_PROPERTY_TO_STRING_H */

--- a/v2/src/log_context_property_to_string.c
+++ b/v2/src/log_context_property_to_string.c
@@ -1,0 +1,150 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdint.h>
+
+#include "macro_utils/macro_utils.h"
+
+#include "c_logging/log_context_property_type.h"
+#include "c_logging/log_context_property_value_pair.h"
+
+#include "c_logging/log_context_property_to_string.h"
+
+#define MIN(a, b) ((a) < (b)) ? (a) : (b)
+
+#define UPDATE_BUFFER_AND_SIZE(result, buffer, buffer_size, no_of_bytes) \
+    no_of_bytes = MIN(no_of_bytes, (int)buffer_size); \
+    buffer += no_of_bytes; \
+    buffer_size -= no_of_bytes; \
+    result += no_of_bytes;
+
+static int log_n_properties(char* buffer, size_t buffer_size, const LOG_CONTEXT_PROPERTY_VALUE_PAIR* property_value_pairs, size_t property_value_pair_count, uint32_t depth, size_t* properties_added)
+{
+    int result = 0;
+
+    /* Codes_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_016: [ For each property: ]*/
+    // Note that for the depth==0 case, we want to iterate over all properties, knowing that we will skip over some for structs
+    // In case we are in depth>0, then we are in a struct and only want to iterate over the property_value_pair_count
+    // BUT, if we have nested structs, we need to skip over those properties at this depth, but not count them against property_value_pair_count
+    size_t properties_added_this_level = 0;
+    size_t i = 0;
+    for (; (depth == 0 && i < property_value_pair_count) || (depth > 0 && properties_added_this_level < property_value_pair_count); i++)
+    {
+        properties_added_this_level++;
+        /* Codes_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_017: [ If the property type is struct (used as a container for context properties): ]*/
+        if (property_value_pairs[i].type->get_type() == LOG_CONTEXT_PROPERTY_TYPE_struct)
+        {
+            /* Codes_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_025: [ log_context_property_to_string shall print the struct property name and an opening brace. ]*/
+            int snprintf_result = snprintf(buffer, buffer_size, " %s%s{", property_value_pairs[i].name, property_value_pairs[i].name[0] == 0 ? "" : "=");
+            if (snprintf_result < 0)
+            {
+                /* Codes_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_022: [ If any encoding error occurs during formatting of the line (i.e. if any printf class functions fails), log_context_property_to_string shall fail and return a negative value. ]*/
+                result = -1;
+                break;
+            }
+            else
+            {
+                UPDATE_BUFFER_AND_SIZE(result, buffer, buffer_size, snprintf_result);
+
+                /* Codes_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_018: [ log_context_property_to_string shall obtain the number of fields in the struct. ]*/
+                uint8_t struct_properties_count = *(uint8_t*)(property_value_pairs[i].value);
+
+                /* Codes_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_019: [ log_context_property_to_string shall print the next n properties as being the fields that are part of the struct. ]*/
+                size_t increment_i = 0;
+                int log_n_properties_result = log_n_properties(buffer, buffer_size, &property_value_pairs[i + 1], struct_properties_count, depth + 1, &increment_i);
+                if (log_n_properties_result < 0)
+                {
+                    /* Codes_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_022: [ If any encoding error occurs during formatting of the line (i.e. if any printf class functions fails), log_context_property_to_string shall fail and return a negative value. ]*/
+                    result = -1;
+                    break;
+                }
+                else
+                {
+                    UPDATE_BUFFER_AND_SIZE(result, buffer, buffer_size, log_n_properties_result);
+
+                    i += increment_i;
+
+                    /* Codes_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_026: [ log_context_property_to_string shall print a closing brace as end of the struct. ]*/
+                    snprintf_result = snprintf(buffer, buffer_size, " }");
+                    if (snprintf_result < 0)
+                    {
+                        /* Codes_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_022: [ If any encoding error occurs during formatting of the line (i.e. if any printf class functions fails), log_context_property_to_string shall fail and return a negative value. ]*/
+                        result = -1;
+                        break;
+                    }
+                    else
+                    {
+                        snprintf_result = MIN(snprintf_result, (int)buffer_size);
+
+                        buffer += snprintf_result;
+                        buffer_size -= snprintf_result;
+                        result += snprintf_result;
+                    }
+                }
+            }
+        }
+        else
+        {
+            /* Codes_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_020: [ Otherwise log_context_property_to_string shall call to_string for the property and print its name and value. ]*/
+            int snprintf_result = snprintf(buffer, buffer_size, " %s=", property_value_pairs[i].name);
+            if (snprintf_result < 0)
+            {
+                result = -1;
+            }
+            else
+            {
+                UPDATE_BUFFER_AND_SIZE(result, buffer, buffer_size, snprintf_result);
+
+                int to_string_result = property_value_pairs[i].type->to_string(property_value_pairs[i].value, buffer, buffer_size);
+
+                if (to_string_result < 0)
+                {
+                    /* Codes_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_022: [ If any encoding error occurs during formatting of the line (i.e. if any printf class functions fails), log_context_property_to_string shall fail and return a negative value. ]*/
+                    result = -1;
+                    break;
+                }
+                else
+                {
+                    UPDATE_BUFFER_AND_SIZE(result, buffer, buffer_size, to_string_result);
+                }
+            }
+        }
+    }
+
+    if (properties_added != NULL)
+    {
+        *properties_added += i;
+    }
+
+    /* Codes_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_021: [ log_context_property_to_string shall store at most buffer_size characters including the null terminator in buffer (the rest of the context shall be truncated). ]*/
+    /* Codes_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_031: [ log_context_property_to_string shall return the number of bytes written to the buffer. ]*/
+
+    return result;
+}
+
+int log_context_property_to_string(char* buffer, size_t buffer_size, const LOG_CONTEXT_PROPERTY_VALUE_PAIR* property_value_pairs, size_t property_value_pair_count)
+{
+    int result;
+
+    if (
+        /*Codes_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_027: [ If buffer is NULL then log_context_property_to_string shall fail and return a negative value. ]*/
+        buffer == NULL ||
+        /*Codes_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_028: [ If buffer_size is 0 then log_context_property_to_string shall return 0. ]*/
+        buffer_size == 0 ||
+        /*Codes_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_029: [ If property_value_pairs is NULL then log_context_property_to_string shall fail and return a negative value. ]*/
+        property_value_pairs == NULL ||
+        /*Codes_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_030: [ If property_value_pair_count is 0 then log_context_property_to_string shall fail and return a negative value. ]*/
+        property_value_pair_count == 0
+        )
+    {
+        result = -1;
+    }
+    else
+    {
+        result = log_n_properties(buffer, buffer_size, property_value_pairs, property_value_pair_count, 0, NULL);
+    }
+
+    return result;
+}

--- a/v2/src/log_context_property_to_string.c
+++ b/v2/src/log_context_property_to_string.c
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#include <stdbool.h>
 #include <stdio.h>
 #include <stdint.h>
 
-#include "macro_utils/macro_utils.h"
-
 #include "c_logging/log_context_property_type.h"
+#include "c_logging/log_context_property_type_if.h"
 #include "c_logging/log_context_property_value_pair.h"
 
 #include "c_logging/log_context_property_to_string.h"

--- a/v2/src/log_sink_console.c
+++ b/v2/src/log_sink_console.c
@@ -11,6 +11,7 @@
 
 #include "c_logging/log_level.h"
 #include "c_logging/log_context.h"
+#include "c_logging/log_context_property_to_string.h"
 #include "c_logging/log_context_property_type.h"
 #include "c_logging/log_context_property_type_if.h"
 #include "c_logging/log_context_property_value_pair.h"
@@ -43,113 +44,6 @@ static const char* level_colors[] =
 };
 
 const char error_string[] = "Error formatting log line\r\n";
-
-#define UPDATE_BUFFER_AND_SIZE(result, buffer, buffer_size, no_of_bytes) \
-    no_of_bytes = MIN(no_of_bytes, (int)buffer_size); \
-    buffer += no_of_bytes; \
-    buffer_size -= no_of_bytes; \
-    result += no_of_bytes;
-
-static int log_n_properties(char* buffer, size_t buffer_size, const LOG_CONTEXT_PROPERTY_VALUE_PAIR* property_value_pairs, size_t property_value_pair_count, uint32_t depth, size_t* properties_added)
-{
-    int result = 0;
-
-    /* Codes_SRS_LOG_SINK_CONSOLE_01_016: [ For each property: ]*/
-    // Note that for the depth==0 case, we want to iterate over all properties, knowing that we will skip over some for structs
-    // In case we are in depth>0, then we are in a struct and only want to iterate over the property_value_pair_count
-    // BUT, if we have nested structs, we need to skip over those properties at this depth, but not count them against property_value_pair_count
-    size_t properties_added_this_level = 0;
-    size_t i = 0;
-    for (; (depth == 0 && i < property_value_pair_count) || (depth > 0 && properties_added_this_level < property_value_pair_count); i++)
-    {
-        properties_added_this_level++;
-        /* Codes_SRS_LOG_SINK_CONSOLE_01_017: [ If the property type is struct (used as a container for context properties): ]*/
-        if (property_value_pairs[i].type->get_type() == LOG_CONTEXT_PROPERTY_TYPE_struct)
-        {
-            /* Codes_SRS_LOG_SINK_CONSOLE_01_025: [ log_sink_console.log shall print the struct property name and an opening brace. ]*/
-            int snprintf_result = snprintf(buffer, buffer_size, " %s%s{", property_value_pairs[i].name, property_value_pairs[i].name[0] == 0 ? "" : "=");
-            if (snprintf_result < 0)
-            {
-                /* Codes_SRS_LOG_SINK_CONSOLE_01_022: [ If any encoding error occurs during formatting of the line (i.e. if any printf class functions fails), log_sink_console.log shall print Error formatting log line and return. ]*/
-                result = -1;
-                break;
-            }
-            else
-            {
-                UPDATE_BUFFER_AND_SIZE(result, buffer, buffer_size, snprintf_result);
-
-                /* Codes_SRS_LOG_SINK_CONSOLE_01_018: [ log_sink_console.log shall obtain the number of fields in the struct. ]*/
-                uint8_t struct_properties_count = *(uint8_t*)(property_value_pairs[i].value);
-
-                /* Codes_SRS_LOG_SINK_CONSOLE_01_019: [ log_sink_console.log shall print the next n properties as being the fields that are part of the struct. ]*/
-                size_t increment_i = 0;
-                int log_n_properties_result = log_n_properties(buffer, buffer_size, &property_value_pairs[i + 1], struct_properties_count, depth + 1, &increment_i);
-                if (log_n_properties_result < 0)
-                {
-                    /* Codes_SRS_LOG_SINK_CONSOLE_01_022: [ If any encoding error occurs during formatting of the line (i.e. if any printf class functions fails), log_sink_console.log shall print Error formatting log line and return. ]*/
-                    result = -1;
-                    break;
-                }
-                else
-                {
-                    UPDATE_BUFFER_AND_SIZE(result, buffer, buffer_size, log_n_properties_result);
-
-                    i += increment_i;
-
-                    /* Codes_SRS_LOG_SINK_CONSOLE_01_026: [ log_sink_console.log shall print a closing brace as end of the struct. ]*/
-                    snprintf_result = snprintf(buffer, buffer_size, " }");
-                    if (snprintf_result < 0)
-                    {
-                        /* Codes_SRS_LOG_SINK_CONSOLE_01_022: [ If any encoding error occurs during formatting of the line (i.e. if any printf class functions fails), log_sink_console.log shall print Error formatting log line and return. ]*/
-                        result = -1;
-                        break;
-                    }
-                    else
-                    {
-                        snprintf_result = MIN(snprintf_result, (int)buffer_size);
-
-                        buffer += snprintf_result;
-                        buffer_size -= snprintf_result;
-                        result += snprintf_result;
-                    }
-                }
-            }
-        }
-        else
-        {
-            /* Codes_SRS_LOG_SINK_CONSOLE_01_020: [ Otherwise log_sink_console.log shall call to_string for the property and print its name and value. ]*/
-            int snprintf_result = snprintf(buffer, buffer_size, " %s=", property_value_pairs[i].name);
-            if (snprintf_result < 0)
-            {
-                result = -1;
-            }
-            else
-            {
-                UPDATE_BUFFER_AND_SIZE(result, buffer, buffer_size, snprintf_result);
-
-                int to_string_result = property_value_pairs[i].type->to_string(property_value_pairs[i].value, buffer, buffer_size);
-
-                if (to_string_result < 0)
-                {
-                    /* Codes_SRS_LOG_SINK_CONSOLE_01_022: [ If any encoding error occurs during formatting of the line (i.e. if any printf class functions fails), log_sink_console.log shall print Error formatting log line and return. ]*/
-                    result = -1;
-                    break;
-                }
-                else
-                {
-                    UPDATE_BUFFER_AND_SIZE(result, buffer, buffer_size, to_string_result);
-                }
-            }
-        }
-    }
-
-    if (properties_added != NULL)
-    {
-        *properties_added += i;
-    }
-
-    return result;
-}
 
 static int log_sink_console_init(void)
 {
@@ -215,7 +109,8 @@ static void log_sink_console_log(LOG_LEVEL log_level, LOG_CONTEXT_HANDLE log_con
                 /* Codes_SRS_LOG_SINK_CONSOLE_01_015: [ log_sink_console.log shall call log_context_get_property_value_pairs to obtain the properties to print. ]*/
                 const LOG_CONTEXT_PROPERTY_VALUE_PAIR* property_value_pairs = log_context_get_property_value_pairs(log_context);
 
-                int log_n_properties_result =  log_n_properties(buffer, buffer_size, property_value_pairs, property_value_pair_count, 0, NULL); // lgtm[cpp/unguardednullreturndereference] Tests and code review ensure that NULL access cannot happen
+                /* Codes_SRS_LOG_SINK_CONSOLE_42_001: [ log_sink_console.log shall call log_context_property_to_string to print the properties to the string buffer. ]*/
+                int log_n_properties_result = log_context_property_to_string(buffer, buffer_size, property_value_pairs, property_value_pair_count); // lgtm[cpp/unguardednullreturndereference] Tests and code review ensure that NULL access cannot happen
                 if (log_n_properties_result < 0)
                 {
                     /* Codes_SRS_LOG_SINK_CONSOLE_01_022: [ If any encoding error occurs during formatting of the line (i.e. if any printf class functions fails), log_sink_console.log shall print Error formatting log line and return. ]*/

--- a/v2/src/log_sink_console.c
+++ b/v2/src/log_sink_console.c
@@ -3,7 +3,6 @@
 
 #include <stdbool.h>
 #include <stdio.h>
-#include <stdint.h>
 #include <stdarg.h>
 #include <time.h>
 
@@ -12,8 +11,6 @@
 #include "c_logging/log_level.h"
 #include "c_logging/log_context.h"
 #include "c_logging/log_context_property_to_string.h"
-#include "c_logging/log_context_property_type.h"
-#include "c_logging/log_context_property_type_if.h"
 #include "c_logging/log_context_property_value_pair.h"
 #include "c_logging/log_sink_if.h"
 #include "c_logging/logger.h"

--- a/v2/tests/CMakeLists.txt
+++ b/v2/tests/CMakeLists.txt
@@ -5,6 +5,7 @@
 if(${run_unittests})
    add_subdirectory(log_context_property_basic_types_ut)
    add_subdirectory(log_context_property_bool_type_ut)
+   add_subdirectory(log_context_property_to_string_ut)
    add_subdirectory(log_context_property_type_ascii_char_ptr_ut)
    add_subdirectory(log_context_property_type_if_ut)
    add_subdirectory(log_context_property_type_struct_ut)

--- a/v2/tests/log_context_property_to_string_ut/CMakeLists.txt
+++ b/v2/tests/log_context_property_to_string_ut/CMakeLists.txt
@@ -1,0 +1,12 @@
+#Copyright (c) Microsoft. All rights reserved.
+#Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+add_executable(log_sink_property_to_string_ut
+    log_sink_property_to_string_ut.c
+    log_sink_property_to_string_mocked.c
+)
+
+include_directories(../../src)
+target_link_libraries(log_sink_property_to_string_ut c_logging_v2)
+add_test(NAME log_sink_property_to_string_ut COMMAND log_sink_property_to_string_ut)
+set_target_properties(log_sink_property_to_string_ut PROPERTIES FOLDER "tests/c_logging_v2")

--- a/v2/tests/log_context_property_to_string_ut/log_sink_property_to_string_mocked.c
+++ b/v2/tests/log_context_property_to_string_ut/log_sink_property_to_string_mocked.c
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include <stdint.h>
+#include <stdio.h>
+
+#include "c_logging/log_context_property_value_pair.h"
+
+#define snprintf mock_snprintf
+
+int mock_snprintf(char* s, size_t n, const char* format, ...);
+
+#include "log_context_property_to_string.c"

--- a/v2/tests/log_context_property_to_string_ut/log_sink_property_to_string_mocked.c
+++ b/v2/tests/log_context_property_to_string_ut/log_sink_property_to_string_mocked.c
@@ -1,10 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#include <stdint.h>
 #include <stdio.h>
-
-#include "c_logging/log_context_property_value_pair.h"
 
 #define snprintf mock_snprintf
 

--- a/v2/tests/log_context_property_to_string_ut/log_sink_property_to_string_ut.c
+++ b/v2/tests/log_context_property_to_string_ut/log_sink_property_to_string_ut.c
@@ -1,0 +1,712 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "macro_utils/macro_utils.h"
+
+#include "c_logging/log_context_property_basic_types.h"
+#include "c_logging/log_context_property_type_ascii_char_ptr.h"
+#include "c_logging/log_context_property_value_pair.h"
+#include "c_logging/log_context.h"
+
+#include "c_logging/log_context_property_to_string.h"
+
+#define LOG_MAX_MESSAGE_LENGTH 4096
+
+// defines how many mock calls we can have
+#define MAX_MOCK_CALL_COUNT (128)
+
+#define MOCK_CALL_TYPE_VALUES \
+    MOCK_CALL_TYPE_snprintf \
+
+MU_DEFINE_ENUM(MOCK_CALL_TYPE, MOCK_CALL_TYPE_VALUES)
+
+// very poor mans mocks :-(
+
+typedef struct snprintf_CALL_TAG
+{
+    bool override_result;
+    int call_result;
+    const char* captured_format_arg;
+} snprintf_CALL;
+
+typedef struct MOCK_CALL_TAG
+{
+    MOCK_CALL_TYPE mock_call_type;
+    union
+    {
+        snprintf_CALL snprintf_call;
+    };
+} MOCK_CALL;
+
+static MOCK_CALL expected_calls[MAX_MOCK_CALL_COUNT];
+static size_t expected_call_count;
+static size_t actual_call_count;
+static bool actual_and_expected_match;
+
+static void setup_mocks(void)
+{
+    expected_call_count = 0;
+    actual_call_count = 0;
+    actual_and_expected_match = true;
+}
+
+int mock_snprintf(char* s, size_t n, const char* format, ...)
+{
+    int result;
+
+    if ((actual_call_count == expected_call_count) ||
+        (expected_calls[actual_call_count].mock_call_type != MOCK_CALL_TYPE_snprintf))
+    {
+        actual_and_expected_match = false;
+        result =-1;
+    }
+    else
+    {
+        if (expected_calls[actual_call_count].snprintf_call.override_result)
+        {
+            result = expected_calls[actual_call_count].snprintf_call.call_result;
+        }
+        else
+        {
+            expected_calls[actual_call_count].snprintf_call.captured_format_arg = format;
+
+            va_list args;
+            va_start(args, format);
+
+            result = vsnprintf(s, n, format, args);
+
+            va_end(args);
+        }
+
+        actual_call_count++;
+    }
+
+    return result;
+}
+
+#define POOR_MANS_ASSERT(cond) \
+    if (!(cond)) \
+    { \
+        (void)printf("%s:%d test failed\r\n", __FUNCTION__, __LINE__); \
+        abort(); \
+    } \
+
+static void setup_snprintf_call(void)
+{
+    expected_calls[expected_call_count].mock_call_type = MOCK_CALL_TYPE_snprintf;
+    expected_calls[expected_call_count].snprintf_call.override_result = false;
+    expected_call_count++;
+}
+
+static void validate_log_line(const char* actual_string, const char* expected_format, const char* expected_log_level_string, const char* file, int line, const char* func, const char* expected_message)
+{
+    char expected_string[LOG_MAX_MESSAGE_LENGTH * 2];
+    int snprintf_result = snprintf(expected_string, sizeof(expected_string), expected_format, expected_log_level_string, file, line, func, expected_message);
+    POOR_MANS_ASSERT(snprintf_result >= 0);
+    char day_of_week[4];
+    char month[4];
+    int day;
+    int hour;
+    int minute;
+    int second;
+    int year;
+    char reset_color_code[10];
+    char anything_else[200];
+    int scanned_values = sscanf(actual_string, expected_string, day_of_week, month, &day, &hour, &minute, &second, &year, reset_color_code, anything_else);
+    POOR_MANS_ASSERT(scanned_values == 8); // the last one should not get scanned as there should be nothing past \r\n
+    size_t actual_string_length = strlen(actual_string);
+    POOR_MANS_ASSERT(actual_string[actual_string_length - 2] == '\r');
+    POOR_MANS_ASSERT(actual_string[actual_string_length - 1] == '\n');
+    POOR_MANS_ASSERT(strcmp(reset_color_code, "\x1b[0m") == 0);
+}
+
+static void validate_property_string(const char* actual_string, const char* expected_format)
+{
+    POOR_MANS_ASSERT(strcmp(actual_string, expected_format) == 0);
+}
+
+/* log_context_property_to_string */
+
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_027: [ If buffer is NULL then log_context_property_to_string shall fail and return a negative value. ]*/
+static void log_context_property_to_string_with_NULL_buffer_fails(void)
+{
+    // arrange
+    LOG_CONTEXT_LOCAL_DEFINE(context_1, NULL, LOG_CONTEXT_PROPERTY(int32_t, x, 42));
+    size_t property_value_pair_count = log_context_get_property_value_pair_count(&context_1);
+    const LOG_CONTEXT_PROPERTY_VALUE_PAIR* property_value_pairs = log_context_get_property_value_pairs(&context_1);
+
+    setup_mocks();
+
+    // act
+    int result = log_context_property_to_string(NULL, LOG_MAX_MESSAGE_LENGTH, property_value_pairs, property_value_pair_count);
+
+    // assert
+    POOR_MANS_ASSERT(result < 0);
+}
+
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_028: [ If buffer_size is 0 then log_context_property_to_string shall return 0. ]*/
+static void log_context_property_to_string_with_0_buffer_size_fails(void)
+{
+    // arrange
+    char buffer[LOG_MAX_MESSAGE_LENGTH];
+
+    LOG_CONTEXT_LOCAL_DEFINE(context_1, NULL, LOG_CONTEXT_PROPERTY(int32_t, x, 42));
+    size_t property_value_pair_count = log_context_get_property_value_pair_count(&context_1);
+    const LOG_CONTEXT_PROPERTY_VALUE_PAIR* property_value_pairs = log_context_get_property_value_pairs(&context_1);
+
+    setup_mocks();
+
+    // act
+    int result = log_context_property_to_string(buffer, 0, property_value_pairs, property_value_pair_count);
+
+    // assert
+    POOR_MANS_ASSERT(result < 0);
+}
+
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_029: [ If property_value_pairs is NULL then log_context_property_to_string shall fail and return a negative value. ]*/
+static void log_context_property_to_string_with_NULL_property_value_pairs_fails(void)
+{
+    // arrange
+    char buffer[LOG_MAX_MESSAGE_LENGTH];
+
+    LOG_CONTEXT_LOCAL_DEFINE(context_1, NULL, LOG_CONTEXT_PROPERTY(int32_t, x, 42));
+    size_t property_value_pair_count = log_context_get_property_value_pair_count(&context_1);
+
+    setup_mocks();
+
+    // act
+    int result = log_context_property_to_string(buffer, LOG_MAX_MESSAGE_LENGTH, NULL, property_value_pair_count);
+
+    // assert
+    POOR_MANS_ASSERT(result < 0);
+}
+
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_030: [ If property_value_pair_count is 0 then log_context_property_to_string shall fail and return a negative value. ]*/
+static void log_context_property_to_string_with_0_property_value_pair_count_fails(void)
+{
+    // arrange
+    char buffer[LOG_MAX_MESSAGE_LENGTH];
+
+    LOG_CONTEXT_LOCAL_DEFINE(context_1, NULL, LOG_CONTEXT_PROPERTY(int32_t, x, 42));
+    const LOG_CONTEXT_PROPERTY_VALUE_PAIR* property_value_pairs = log_context_get_property_value_pairs(&context_1);
+
+    setup_mocks();
+
+    // act
+    int result = log_context_property_to_string(buffer, LOG_MAX_MESSAGE_LENGTH, property_value_pairs, 0);
+
+    // assert
+    POOR_MANS_ASSERT(result < 0);
+}
+
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_016: [ For each property: ]*/
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_017: [ If the property type is struct (used as a container for context properties): ]*/
+  /* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_025: [ log_context_property_to_string shall print the struct property name and an opening brace. ]*/
+  /* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_018: [ log_context_property_to_string shall obtain the number of fields in the struct. ]*/
+  /* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_019: [ log_context_property_to_string shall print the next n properties as being the fields that are part of the struct. ]*/
+  /* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_026: [ log_context_property_to_string shall print a closing brace as end of the struct. ]*/
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_020: [ Otherwise log_context_property_to_string shall call to_string for the property and print its name and value. ]*/
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_031: [ log_context_property_to_string shall return the number of bytes written to the buffer. ]*/
+static void log_context_property_to_string_with_single_property_no_struct(void)
+{
+    // arrange
+    char buffer[LOG_MAX_MESSAGE_LENGTH];
+
+    uint32_t x = 42;
+    size_t property_value_pair_count = 1;
+    LOG_CONTEXT_PROPERTY_VALUE_PAIR property_value_pair;
+    property_value_pair.name = "x";
+    property_value_pair.value = &x;
+    property_value_pair.type = &int32_t_log_context_property_type;
+
+    setup_mocks();
+
+    setup_snprintf_call(); // property
+
+    // act
+    int result = log_context_property_to_string(buffer, LOG_MAX_MESSAGE_LENGTH, &property_value_pair, property_value_pair_count);
+
+    // assert
+    POOR_MANS_ASSERT(expected_call_count == actual_call_count);
+    POOR_MANS_ASSERT(actual_and_expected_match);
+    const char expected_string[] = " x=42";
+    validate_property_string(buffer, expected_string);
+    POOR_MANS_ASSERT(result == sizeof(expected_string) - 1);
+}
+
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_016: [ For each property: ]*/
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_017: [ If the property type is struct (used as a container for context properties): ]*/
+  /* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_025: [ log_context_property_to_string shall print the struct property name and an opening brace. ]*/
+  /* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_018: [ log_context_property_to_string shall obtain the number of fields in the struct. ]*/
+  /* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_019: [ log_context_property_to_string shall print the next n properties as being the fields that are part of the struct. ]*/
+  /* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_026: [ log_context_property_to_string shall print a closing brace as end of the struct. ]*/
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_020: [ Otherwise log_context_property_to_string shall call to_string for the property and print its name and value. ]*/
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_031: [ log_context_property_to_string shall return the number of bytes written to the buffer. ]*/
+static void log_context_property_to_string_with_non_NULL_context_prints_one_property(void)
+{
+    // arrange
+    char buffer[LOG_MAX_MESSAGE_LENGTH];
+
+    LOG_CONTEXT_LOCAL_DEFINE(context_1, NULL, LOG_CONTEXT_PROPERTY(int32_t, x, 42));
+    size_t property_value_pair_count = log_context_get_property_value_pair_count(&context_1);
+    const LOG_CONTEXT_PROPERTY_VALUE_PAIR* property_value_pairs = log_context_get_property_value_pairs(&context_1);
+
+    setup_mocks();
+
+    setup_snprintf_call(); // context opening
+    setup_snprintf_call(); // property
+    setup_snprintf_call(); // context closing
+
+    // act
+    int result = log_context_property_to_string(buffer, LOG_MAX_MESSAGE_LENGTH, property_value_pairs, property_value_pair_count);
+
+    // assert
+    POOR_MANS_ASSERT(expected_call_count == actual_call_count);
+    POOR_MANS_ASSERT(actual_and_expected_match);
+    const char expected_string[] = " { x=42 }";
+    validate_property_string(buffer, expected_string);
+    POOR_MANS_ASSERT(result == sizeof(expected_string) - 1);
+}
+
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_016: [ For each property: ]*/
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_017: [ If the property type is struct (used as a container for context properties): ]*/
+  /* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_025: [ log_context_property_to_string shall print the struct property name and an opening brace. ]*/
+  /* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_018: [ log_context_property_to_string shall obtain the number of fields in the struct. ]*/
+  /* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_019: [ log_context_property_to_string shall print the next n properties as being the fields that are part of the struct. ]*/
+  /* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_026: [ log_context_property_to_string shall print a closing brace as end of the struct. ]*/
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_020: [ Otherwise log_context_property_to_string shall call to_string for the property and print its name and value. ]*/
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_031: [ log_context_property_to_string shall return the number of bytes written to the buffer. ]*/
+static void log_context_property_to_string_with_non_NULL_context_prints_2_properties(void)
+{
+    // arrange
+    char buffer[LOG_MAX_MESSAGE_LENGTH];
+
+    LOG_CONTEXT_LOCAL_DEFINE(context_1, NULL, LOG_CONTEXT_PROPERTY(int32_t, x, 42), LOG_CONTEXT_PROPERTY(uint32_t, y, 1));
+    size_t property_value_pair_count = log_context_get_property_value_pair_count(&context_1);
+    const LOG_CONTEXT_PROPERTY_VALUE_PAIR* property_value_pairs = log_context_get_property_value_pairs(&context_1);
+
+    setup_mocks();
+
+    setup_snprintf_call(); // context opening
+    setup_snprintf_call(); // property
+    setup_snprintf_call(); // property
+    setup_snprintf_call(); // context closing
+
+    // act
+    int result = log_context_property_to_string(buffer, LOG_MAX_MESSAGE_LENGTH, property_value_pairs, property_value_pair_count);
+
+    // assert
+    POOR_MANS_ASSERT(expected_call_count == actual_call_count);
+    POOR_MANS_ASSERT(actual_and_expected_match);
+    const char expected_string[] = " { x=42 y=1 }";
+    validate_property_string(buffer, expected_string);
+    POOR_MANS_ASSERT(result == sizeof(expected_string) - 1);
+}
+
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_016: [ For each property: ]*/
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_017: [ If the property type is struct (used as a container for context properties): ]*/
+  /* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_025: [ log_context_property_to_string shall print the struct property name and an opening brace. ]*/
+  /* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_018: [ log_context_property_to_string shall obtain the number of fields in the struct. ]*/
+  /* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_019: [ log_context_property_to_string shall print the next n properties as being the fields that are part of the struct. ]*/
+  /* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_026: [ log_context_property_to_string shall print a closing brace as end of the struct. ]*/
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_020: [ Otherwise log_context_property_to_string shall call to_string for the property and print its name and value. ]*/
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_031: [ log_context_property_to_string shall return the number of bytes written to the buffer. ]*/
+static void log_context_property_to_string_with_non_NULL_context_with_2_levels_works(void)
+{
+    // arrange
+    char buffer[LOG_MAX_MESSAGE_LENGTH];
+
+    LOG_CONTEXT_LOCAL_DEFINE(context_1, NULL, LOG_CONTEXT_PROPERTY(int32_t, x, 42));
+    LOG_CONTEXT_LOCAL_DEFINE(context_2, &context_1, LOG_CONTEXT_PROPERTY(uint32_t, y, 1));
+    size_t property_value_pair_count = log_context_get_property_value_pair_count(&context_2);
+    const LOG_CONTEXT_PROPERTY_VALUE_PAIR* property_value_pairs = log_context_get_property_value_pairs(&context_2);
+
+    setup_mocks();
+
+    setup_snprintf_call(); // context opening
+    setup_snprintf_call(); // context opening
+    setup_snprintf_call(); // property
+    setup_snprintf_call(); // context closing
+    setup_snprintf_call(); // property
+    setup_snprintf_call(); // context closing
+
+    // act
+    int result = log_context_property_to_string(buffer, LOG_MAX_MESSAGE_LENGTH, property_value_pairs, property_value_pair_count);
+
+    // assert
+    POOR_MANS_ASSERT(expected_call_count == actual_call_count);
+    POOR_MANS_ASSERT(actual_and_expected_match);
+    const char expected_string[] = " { { x=42 } y=1 }";
+    validate_property_string(buffer, expected_string);
+    POOR_MANS_ASSERT(result == sizeof(expected_string) - 1);
+}
+
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_016: [ For each property: ]*/
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_017: [ If the property type is struct (used as a container for context properties): ]*/
+  /* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_025: [ log_context_property_to_string shall print the struct property name and an opening brace. ]*/
+  /* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_018: [ log_context_property_to_string shall obtain the number of fields in the struct. ]*/
+  /* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_019: [ log_context_property_to_string shall print the next n properties as being the fields that are part of the struct. ]*/
+  /* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_026: [ log_context_property_to_string shall print a closing brace as end of the struct. ]*/
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_020: [ Otherwise log_context_property_to_string shall call to_string for the property and print its name and value. ]*/
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_031: [ log_context_property_to_string shall return the number of bytes written to the buffer. ]*/
+static void log_context_property_to_string_with_non_NULL_named_contexts_with_2_levels_works(void)
+{
+    // arrange
+    char buffer[LOG_MAX_MESSAGE_LENGTH];
+
+    LOG_CONTEXT_LOCAL_DEFINE(context_1, NULL, LOG_CONTEXT_NAME(haga), LOG_CONTEXT_PROPERTY(int32_t, x, 42));
+    LOG_CONTEXT_LOCAL_DEFINE(context_2, &context_1, LOG_CONTEXT_NAME(uaga), LOG_CONTEXT_PROPERTY(uint32_t, y, 1));
+    size_t property_value_pair_count = log_context_get_property_value_pair_count(&context_2);
+    const LOG_CONTEXT_PROPERTY_VALUE_PAIR* property_value_pairs = log_context_get_property_value_pairs(&context_2);
+
+    setup_mocks();
+
+    setup_snprintf_call(); // context opening
+    setup_snprintf_call(); // context opening
+    setup_snprintf_call(); // property
+    setup_snprintf_call(); // context closing
+    setup_snprintf_call(); // property
+    setup_snprintf_call(); // context closing
+
+    // act
+    int result = log_context_property_to_string(buffer, LOG_MAX_MESSAGE_LENGTH, property_value_pairs, property_value_pair_count);
+
+    // assert
+    POOR_MANS_ASSERT(expected_call_count == actual_call_count);
+    POOR_MANS_ASSERT(actual_and_expected_match);
+    const char expected_string[] = " uaga={ haga={ x=42 } y=1 }";
+    validate_property_string(buffer, expected_string);
+    POOR_MANS_ASSERT(result == sizeof(expected_string) - 1);
+}
+
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_016: [ For each property: ]*/
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_017: [ If the property type is struct (used as a container for context properties): ]*/
+  /* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_025: [ log_context_property_to_string shall print the struct property name and an opening brace. ]*/
+  /* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_018: [ log_context_property_to_string shall obtain the number of fields in the struct. ]*/
+  /* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_026: [ log_context_property_to_string shall print a closing brace as end of the struct. ]*/
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_020: [ Otherwise log_context_property_to_string shall call to_string for the property and print its name and value. ]*/
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_031: [ log_context_property_to_string shall return the number of bytes written to the buffer. ]*/
+static void log_context_property_to_string_with_non_NULL_empty_context_works(void)
+{
+    // arrange
+    char buffer[LOG_MAX_MESSAGE_LENGTH];
+
+    LOG_CONTEXT_LOCAL_DEFINE(context_1, NULL);
+    size_t property_value_pair_count = log_context_get_property_value_pair_count(&context_1);
+    const LOG_CONTEXT_PROPERTY_VALUE_PAIR* property_value_pairs = log_context_get_property_value_pairs(&context_1);
+
+    setup_mocks();
+
+    setup_snprintf_call(); // context opening
+    setup_snprintf_call(); // context closing
+
+    // act
+    int result = log_context_property_to_string(buffer, LOG_MAX_MESSAGE_LENGTH, property_value_pairs, property_value_pair_count);
+
+    // assert
+    POOR_MANS_ASSERT(expected_call_count == actual_call_count);
+    POOR_MANS_ASSERT(actual_and_expected_match);
+    const char expected_string[] = " { }";
+    validate_property_string(buffer, expected_string);
+    POOR_MANS_ASSERT(result == sizeof(expected_string) - 1);
+}
+
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_016: [ For each property: ]*/
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_017: [ If the property type is struct (used as a container for context properties): ]*/
+  /* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_025: [ log_context_property_to_string shall print the struct property name and an opening brace. ]*/
+  /* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_018: [ log_context_property_to_string shall obtain the number of fields in the struct. ]*/
+  /* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_019: [ log_context_property_to_string shall print the next n properties as being the fields that are part of the struct. ]*/
+  /* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_026: [ log_context_property_to_string shall print a closing brace as end of the struct. ]*/
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_020: [ Otherwise log_context_property_to_string shall call to_string for the property and print its name and value. ]*/
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_031: [ log_context_property_to_string shall return the number of bytes written to the buffer. ]*/
+static void log_context_property_to_string_with_non_NULL_dynamically_allocated_context(void)
+{
+    // arrange
+    char buffer[LOG_MAX_MESSAGE_LENGTH];
+
+    LOG_CONTEXT_HANDLE context_1;
+    LOG_CONTEXT_CREATE(context_1, NULL, LOG_CONTEXT_PROPERTY(int32_t, x, 42));
+    LOG_CONTEXT_HANDLE context_2;
+    LOG_CONTEXT_CREATE(context_2, context_1, LOG_CONTEXT_PROPERTY(uint32_t, y, 1));
+    size_t property_value_pair_count = log_context_get_property_value_pair_count(context_2);
+    const LOG_CONTEXT_PROPERTY_VALUE_PAIR* property_value_pairs = log_context_get_property_value_pairs(context_2);
+
+    setup_mocks();
+
+    setup_snprintf_call(); // context opening
+    setup_snprintf_call(); // context opening
+    setup_snprintf_call(); // property
+    setup_snprintf_call(); // context closing
+    setup_snprintf_call(); // property
+    setup_snprintf_call(); // context closing
+
+    // act
+    int result = log_context_property_to_string(buffer, LOG_MAX_MESSAGE_LENGTH, property_value_pairs, property_value_pair_count);
+
+    // assert
+    POOR_MANS_ASSERT(expected_call_count == actual_call_count);
+    POOR_MANS_ASSERT(actual_and_expected_match);
+    const char expected_string[] = " { { x=42 } y=1 }";
+    validate_property_string(buffer, expected_string);
+    POOR_MANS_ASSERT(result == sizeof(expected_string) - 1);
+
+    // cleanup
+    LOG_CONTEXT_DESTROY(context_1);
+    LOG_CONTEXT_DESTROY(context_2);
+}
+
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_022: [ If any encoding error occurs during formatting of the line (i.e. if any printf class functions fails), log_context_property_to_string shall fail and return a negative value. ]*/
+static void when_snprintf_fails_for_context_open_brace_log_context_property_to_string_fails(void)
+{
+    // arrange
+    char buffer[LOG_MAX_MESSAGE_LENGTH];
+
+    LOG_CONTEXT_LOCAL_DEFINE(context_1, NULL, LOG_CONTEXT_PROPERTY(int32_t, x, 42));
+    LOG_CONTEXT_LOCAL_DEFINE(context_2, &context_1, LOG_CONTEXT_PROPERTY(uint32_t, y, 1));
+    size_t property_value_pair_count = log_context_get_property_value_pair_count(&context_2);
+    const LOG_CONTEXT_PROPERTY_VALUE_PAIR* property_value_pairs = log_context_get_property_value_pairs(&context_2);
+
+    setup_mocks();
+
+    setup_snprintf_call(); // context opening
+
+    expected_calls[0].snprintf_call.override_result = true;
+    expected_calls[0].snprintf_call.call_result = -1;
+
+    // act
+    int result = log_context_property_to_string(buffer, LOG_MAX_MESSAGE_LENGTH, property_value_pairs, property_value_pair_count);
+
+    // assert
+    POOR_MANS_ASSERT(expected_call_count == actual_call_count);
+    POOR_MANS_ASSERT(actual_and_expected_match);
+    POOR_MANS_ASSERT(result < 0);
+}
+
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_022: [ If any encoding error occurs during formatting of the line (i.e. if any printf class functions fails), log_context_property_to_string shall fail and return a negative value. ]*/
+static void when_snprintf_fails_for_inner_context_open_brace_log_context_property_to_string_fails(void)
+{
+    // arrange
+    char buffer[LOG_MAX_MESSAGE_LENGTH];
+
+    LOG_CONTEXT_LOCAL_DEFINE(context_1, NULL, LOG_CONTEXT_PROPERTY(int32_t, x, 42));
+    LOG_CONTEXT_LOCAL_DEFINE(context_2, &context_1, LOG_CONTEXT_PROPERTY(uint32_t, y, 1));
+    size_t property_value_pair_count = log_context_get_property_value_pair_count(&context_2);
+    const LOG_CONTEXT_PROPERTY_VALUE_PAIR* property_value_pairs = log_context_get_property_value_pairs(&context_2);
+
+    setup_mocks();
+
+    setup_snprintf_call(); // context opening
+    setup_snprintf_call(); // context opening
+
+    expected_calls[1].snprintf_call.override_result = true;
+    expected_calls[1].snprintf_call.call_result = -1;
+
+    // act
+    int result = log_context_property_to_string(buffer, LOG_MAX_MESSAGE_LENGTH, property_value_pairs, property_value_pair_count);
+
+    // assert
+    POOR_MANS_ASSERT(expected_call_count == actual_call_count);
+    POOR_MANS_ASSERT(actual_and_expected_match);
+    POOR_MANS_ASSERT(result < 0);
+}
+
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_022: [ If any encoding error occurs during formatting of the line (i.e. if any printf class functions fails), log_context_property_to_string shall fail and return a negative value. ]*/
+static void when_snprintf_fails_for_property_in_inner_context_log_context_property_to_string_fails(void)
+{
+    // arrange
+    char buffer[LOG_MAX_MESSAGE_LENGTH];
+
+    LOG_CONTEXT_LOCAL_DEFINE(context_1, NULL, LOG_CONTEXT_PROPERTY(int32_t, x, 42));
+    LOG_CONTEXT_LOCAL_DEFINE(context_2, &context_1, LOG_CONTEXT_PROPERTY(uint32_t, y, 1));
+    size_t property_value_pair_count = log_context_get_property_value_pair_count(&context_2);
+    const LOG_CONTEXT_PROPERTY_VALUE_PAIR* property_value_pairs = log_context_get_property_value_pairs(&context_2);
+
+    setup_mocks();
+
+    setup_snprintf_call(); // context opening
+    setup_snprintf_call(); // context opening
+    setup_snprintf_call(); // property
+
+    expected_calls[2].snprintf_call.override_result = true;
+    expected_calls[2].snprintf_call.call_result = -1;
+
+    // act
+    int result = log_context_property_to_string(buffer, LOG_MAX_MESSAGE_LENGTH, property_value_pairs, property_value_pair_count);
+
+    // assert
+    POOR_MANS_ASSERT(expected_call_count == actual_call_count);
+    POOR_MANS_ASSERT(actual_and_expected_match);
+    POOR_MANS_ASSERT(result < 0);
+}
+
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_022: [ If any encoding error occurs during formatting of the line (i.e. if any printf class functions fails), log_context_property_to_string shall fail and return a negative value. ]*/
+static void when_snprintf_fails_for_closing_of_inner_context_log_context_property_to_string_fails(void)
+{
+    // arrange
+    char buffer[LOG_MAX_MESSAGE_LENGTH];
+
+    LOG_CONTEXT_LOCAL_DEFINE(context_1, NULL, LOG_CONTEXT_PROPERTY(int32_t, x, 42));
+    LOG_CONTEXT_LOCAL_DEFINE(context_2, &context_1, LOG_CONTEXT_PROPERTY(uint32_t, y, 1));
+    size_t property_value_pair_count = log_context_get_property_value_pair_count(&context_2);
+    const LOG_CONTEXT_PROPERTY_VALUE_PAIR* property_value_pairs = log_context_get_property_value_pairs(&context_2);
+
+    setup_mocks();
+
+    setup_snprintf_call(); // context opening
+    setup_snprintf_call(); // context opening
+    setup_snprintf_call(); // property
+    setup_snprintf_call(); // context closing
+
+    expected_calls[3].snprintf_call.override_result = true;
+    expected_calls[3].snprintf_call.call_result = -1;
+
+    // act
+    int result = log_context_property_to_string(buffer, LOG_MAX_MESSAGE_LENGTH, property_value_pairs, property_value_pair_count);
+
+    // assert
+    POOR_MANS_ASSERT(expected_call_count == actual_call_count);
+    POOR_MANS_ASSERT(actual_and_expected_match);
+    POOR_MANS_ASSERT(result < 0);
+}
+
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_022: [ If any encoding error occurs during formatting of the line (i.e. if any printf class functions fails), log_context_property_to_string shall fail and return a negative value. ]*/
+static void when_snprintf_fails_for_property_in_outer_context_log_context_property_to_string_fails(void)
+{
+    // arrange
+    char buffer[LOG_MAX_MESSAGE_LENGTH];
+
+    LOG_CONTEXT_LOCAL_DEFINE(context_1, NULL, LOG_CONTEXT_PROPERTY(int32_t, x, 42));
+    LOG_CONTEXT_LOCAL_DEFINE(context_2, &context_1, LOG_CONTEXT_PROPERTY(uint32_t, y, 1));
+    size_t property_value_pair_count = log_context_get_property_value_pair_count(&context_2);
+    const LOG_CONTEXT_PROPERTY_VALUE_PAIR* property_value_pairs = log_context_get_property_value_pairs(&context_2);
+
+    setup_mocks();
+
+    setup_snprintf_call(); // context opening
+    setup_snprintf_call(); // context opening
+    setup_snprintf_call(); // property
+    setup_snprintf_call(); // context closing
+    setup_snprintf_call(); // property
+
+    expected_calls[4].snprintf_call.override_result = true;
+    expected_calls[4].snprintf_call.call_result = -1;
+
+    // act
+    int result = log_context_property_to_string(buffer, LOG_MAX_MESSAGE_LENGTH, property_value_pairs, property_value_pair_count);
+
+    // assert
+    POOR_MANS_ASSERT(expected_call_count == actual_call_count);
+    POOR_MANS_ASSERT(actual_and_expected_match);
+    POOR_MANS_ASSERT(result < 0);
+}
+
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_022: [ If any encoding error occurs during formatting of the line (i.e. if any printf class functions fails), log_context_property_to_string shall fail and return a negative value. ]*/
+static void when_snprintf_fails_for_closing_of_outer_context_log_context_property_to_string_fails(void)
+{
+    // arrange
+    char buffer[LOG_MAX_MESSAGE_LENGTH];
+
+    LOG_CONTEXT_LOCAL_DEFINE(context_1, NULL, LOG_CONTEXT_PROPERTY(int32_t, x, 42));
+    LOG_CONTEXT_LOCAL_DEFINE(context_2, &context_1, LOG_CONTEXT_PROPERTY(uint32_t, y, 1));
+    size_t property_value_pair_count = log_context_get_property_value_pair_count(&context_2);
+    const LOG_CONTEXT_PROPERTY_VALUE_PAIR* property_value_pairs = log_context_get_property_value_pairs(&context_2);
+
+    setup_mocks();
+
+    setup_snprintf_call(); // context opening
+    setup_snprintf_call(); // context opening
+    setup_snprintf_call(); // property
+    setup_snprintf_call(); // context closing
+    setup_snprintf_call(); // property
+    setup_snprintf_call(); // context closing
+
+    expected_calls[5].snprintf_call.override_result = true;
+    expected_calls[5].snprintf_call.call_result = -1;
+
+    // act
+    int result = log_context_property_to_string(buffer, LOG_MAX_MESSAGE_LENGTH, property_value_pairs, property_value_pair_count);
+
+    // assert
+    POOR_MANS_ASSERT(expected_call_count == actual_call_count);
+    POOR_MANS_ASSERT(actual_and_expected_match);
+    POOR_MANS_ASSERT(result < 0);
+}
+
+/* Tests_SRS_LOG_CONTEXT_PROPERTY_TO_STRING_42_021: [ log_context_property_to_string shall store at most buffer_size characters including the null terminator in buffer (the rest of the context shall be truncated). ]*/
+static void when_printing_a_property_value_exceeds_log_line_size_it_is_truncated(void)
+{
+    // arrange
+    char buffer[LOG_MAX_MESSAGE_LENGTH];
+
+    char* string_property_value_too_big = malloc(LOG_MAX_MESSAGE_LENGTH);
+    POOR_MANS_ASSERT(string_property_value_too_big != NULL);
+
+    (void)memset(string_property_value_too_big, 'x', LOG_MAX_MESSAGE_LENGTH - 1);
+    string_property_value_too_big[LOG_MAX_MESSAGE_LENGTH - 1] = '\0';
+
+    LOG_CONTEXT_HANDLE context_1;
+    LOG_CONTEXT_CREATE(context_1, NULL, LOG_CONTEXT_STRING_PROPERTY(hagauaga, "%s", string_property_value_too_big));
+    size_t property_value_pair_count = log_context_get_property_value_pair_count(context_1);
+    const LOG_CONTEXT_PROPERTY_VALUE_PAIR* property_value_pairs = log_context_get_property_value_pairs(context_1);
+
+    setup_mocks();
+
+    setup_snprintf_call(); // context opening
+    setup_snprintf_call(); // context opening
+    setup_snprintf_call(); // property
+
+    // act
+    int result = log_context_property_to_string(buffer, LOG_MAX_MESSAGE_LENGTH, property_value_pairs, property_value_pair_count);
+
+    // assert
+    POOR_MANS_ASSERT(expected_call_count == actual_call_count);
+    POOR_MANS_ASSERT(actual_and_expected_match);
+
+    char expected_string[LOG_MAX_MESSAGE_LENGTH];
+    (void)snprintf(expected_string, sizeof(expected_string), " { hagauaga=%s }", string_property_value_too_big);
+
+    validate_property_string(buffer, expected_string);
+    POOR_MANS_ASSERT(result == LOG_MAX_MESSAGE_LENGTH);
+
+    // cleanup
+    free(string_property_value_too_big);
+    LOG_CONTEXT_DESTROY(context_1);
+}
+
+/* very "poor man's" way of testing, as no test harness and mocking framework are available */
+int main(void)
+{
+    log_context_property_to_string_with_NULL_buffer_fails();
+    log_context_property_to_string_with_0_buffer_size_fails();
+    log_context_property_to_string_with_NULL_property_value_pairs_fails();
+    log_context_property_to_string_with_0_property_value_pair_count_fails();
+
+    log_context_property_to_string_with_single_property_no_struct();
+    log_context_property_to_string_with_non_NULL_context_prints_one_property();
+    log_context_property_to_string_with_non_NULL_context_prints_2_properties();
+    log_context_property_to_string_with_non_NULL_context_with_2_levels_works();
+
+    log_context_property_to_string_with_non_NULL_named_contexts_with_2_levels_works();
+
+    log_context_property_to_string_with_non_NULL_empty_context_works();
+
+    log_context_property_to_string_with_non_NULL_dynamically_allocated_context();
+
+    when_snprintf_fails_for_context_open_brace_log_context_property_to_string_fails();
+    when_snprintf_fails_for_inner_context_open_brace_log_context_property_to_string_fails();
+    when_snprintf_fails_for_property_in_inner_context_log_context_property_to_string_fails();
+    when_snprintf_fails_for_closing_of_inner_context_log_context_property_to_string_fails();
+    when_snprintf_fails_for_property_in_outer_context_log_context_property_to_string_fails();
+    when_snprintf_fails_for_closing_of_outer_context_log_context_property_to_string_fails();
+
+    when_printing_a_property_value_exceeds_log_line_size_it_is_truncated();
+
+    return 0;
+}

--- a/v2/tests/log_sink_console_ut/log_sink_console_mocked.c
+++ b/v2/tests/log_sink_console_ut/log_sink_console_mocked.c
@@ -6,6 +6,7 @@
 #include <time.h>
 
 #include "c_logging/log_context.h"
+#include "c_logging/log_context_property_to_string.h"
 #include "c_logging/log_context_property_value_pair.h"
 
 #define printf mock_printf
@@ -15,6 +16,7 @@
 #define snprintf mock_snprintf
 #define log_context_get_property_value_pair_count mock_log_context_get_property_value_pair_count
 #define log_context_get_property_value_pairs mock_log_context_get_property_value_pairs
+#define log_context_property_to_string mock_log_context_property_to_string
 
 int mock_printf(const char* format, ...);
 time_t mock_time(time_t* const _time);
@@ -23,5 +25,6 @@ int mock_vsnprintf(char* s, size_t n, const char* format, va_list arg);
 int mock_snprintf(char* s, size_t n, const char* format, ...);
 uint32_t mock_log_context_get_property_value_pair_count(LOG_CONTEXT_HANDLE log_context);
 const LOG_CONTEXT_PROPERTY_VALUE_PAIR* mock_log_context_get_property_value_pairs(LOG_CONTEXT_HANDLE log_context);
+int mock_log_context_property_to_string(char* buffer, size_t buffer_size, const LOG_CONTEXT_PROPERTY_VALUE_PAIR* property_value_pairs, size_t property_value_pair_count);
 
 #include "log_sink_console.c"

--- a/v2/tests/log_sink_console_ut/log_sink_console_mocked.c
+++ b/v2/tests/log_sink_console_ut/log_sink_console_mocked.c
@@ -6,7 +6,6 @@
 #include <time.h>
 
 #include "c_logging/log_context.h"
-#include "c_logging/log_context_property_to_string.h"
 #include "c_logging/log_context_property_value_pair.h"
 
 #define printf mock_printf


### PR DESCRIPTION
for use with other log sinks that also want to convert all of the data to text