### PR TITLE
Make max log level for log_sink_callback configurable

### DIFF
--- a/v2/devdoc/log_sink_callback_requirements.md
+++ b/v2/devdoc/log_sink_callback_requirements.md
@@ -9,6 +9,7 @@ Note that this assumes the other logging system cares about only the level and t
 ```c
     typedef void (*LOG_SINK_CALLBACK_LOG)(void* context, LOG_LEVEL log_level, const char* message);
     int log_sink_callback_set_callback(LOG_SINK_CALLBACK_LOG log_callback, void* context);
+    void log_sink_callback_set_max_level(LOG_LEVEL log_level);
 
     extern const LOG_SINK_IF log_sink_callback;
 ```
@@ -49,6 +50,16 @@ int log_sink_callback_set_callback(LOG_SINK_CALLBACK_LOG log_callback, void* con
 
 **SRS_LOG_SINK_CALLBACK_42_005: [** `log_sink_callback_set_callback` shall return 0. **]**
 
+### log_sink_callback_set_max_level
+
+```c
+void log_sink_callback_set_max_level(LOG_LEVEL log_level);
+```
+
+`log_sink_callback_set_max_level` sets the maximum log level that will be passed to the callback. Log messages with a level higher than this (more verbose) will be dropped. This avoids additional string processing on the log messages that will be dropped. This function is not thread-safe. If called during normal operation to change the log level, some threads may continue to log messages at the old level for some time.
+
+**SRS_LOG_SINK_CALLBACK_42_019: [** `log_sink_callback_set_max_level` shall store `log_level` so that it is used by all future calls to `log_sink_callback.log`. **]**
+
 ### log_sink_callback.log
 
 The signature of `log_sink_callback.log` is:
@@ -60,6 +71,8 @@ typedef void (*LOG_SINK_LOG_FUNC)(LOG_LEVEL log_level, LOG_CONTEXT_HANDLE log_co
 `log_sink_callback.log` implements logging to a string which is passed to a callback function. The setup function `log_sink_callback_set_callback` must be called or the callback will just be a no-op.
 
 **SRS_LOG_SINK_CALLBACK_42_006: [** If `message_format` is `NULL`, `log_sink_callback.log` shall call the `log_callback` with an error message and return. **]**
+
+**SRS_LOG_SINK_CALLBACK_42_020: [** If `log_level` is greater than the maximum level set by `log_sink_callback_set_max_level`, then `log_sink_callback.log` shall return without calling the `log_callback`. **]**
 
 **SRS_LOG_SINK_CALLBACK_42_007: [** `log_sink_callback.log` shall obtain the time by calling `time`. **]**
 

--- a/v2/inc/c_logging/log_sink_callback.h
+++ b/v2/inc/c_logging/log_sink_callback.h
@@ -12,6 +12,7 @@ extern "C" {
 
     typedef void (*LOG_SINK_CALLBACK_LOG)(void* context, LOG_LEVEL log_level, const char* message);
     int log_sink_callback_set_callback(LOG_SINK_CALLBACK_LOG log_callback, void* context);
+    void log_sink_callback_set_max_level(LOG_LEVEL log_level);
 
     extern const LOG_SINK_IF log_sink_callback;
 

--- a/v2/tests/log_sink_callback_int/log_sink_callback_int.c
+++ b/v2/tests/log_sink_callback_int/log_sink_callback_int.c
@@ -381,6 +381,106 @@ static void log_sink_callback_with_a_context_with_boolean_false_works(void)
     LOG_CONTEXT_DESTROY(test_context);
 }
 
+static void test_case_log_sink_callback_is_called_with_max_level(LOG_LEVEL log_level, LOG_LEVEL max_log_level)
+{
+    // arrange
+    log_sink_callback_set_max_level(max_log_level);
+    uint32_t count_before = log_callback_context.message_count;
+
+    // act
+    test_log_sink_callback_log(log_level, NULL, __FILE__, __FUNCTION__, __LINE__, "a");
+
+    // assert
+    assert_log_message_received(count_before, log_level, __FILE__, __FUNCTION__, NULL, "a");
+
+    // cleanup
+    log_sink_callback_set_max_level(LOG_LEVEL_VERBOSE);
+}
+
+static void test_case_log_sink_callback_is_not_called_with_max_level(LOG_LEVEL log_level, LOG_LEVEL max_log_level)
+{
+    // arrange
+    log_sink_callback_set_max_level(max_log_level);
+    uint32_t count_before = log_callback_context.message_count;
+
+    // act
+    test_log_sink_callback_log(log_level, NULL, __FILE__, __FUNCTION__, __LINE__, "a");
+
+    // assert
+    POOR_MANS_ASSERT(log_callback_context.message_count == count_before);
+
+    // cleanup
+    log_sink_callback_set_max_level(LOG_LEVEL_VERBOSE);
+}
+
+static void log_sink_callback_log_calls_callback_for_all_log_levels_when_max_level_is_VERBOSE(void)
+{
+    for (LOG_LEVEL log_level = LOG_LEVEL_CRITICAL; log_level <= LOG_LEVEL_VERBOSE; log_level++)
+    {
+        test_case_log_sink_callback_is_called_with_max_level(log_level, LOG_LEVEL_VERBOSE);
+    }
+}
+
+static void log_sink_callback_log_calls_callback_for_all_log_levels_INFO_and_lower_when_max_level_is_INFO(void)
+{
+    for (LOG_LEVEL log_level = LOG_LEVEL_CRITICAL; log_level <= LOG_LEVEL_VERBOSE; log_level++)
+    {
+        if (log_level > LOG_LEVEL_INFO)
+        {
+            test_case_log_sink_callback_is_not_called_with_max_level(log_level, LOG_LEVEL_INFO);
+        }
+        else
+        {
+            test_case_log_sink_callback_is_called_with_max_level(log_level, LOG_LEVEL_INFO);
+        }
+    }
+}
+
+static void log_sink_callback_log_calls_callback_for_all_log_levels_WARNING_and_lower_when_max_level_is_WARNING(void)
+{
+    for (LOG_LEVEL log_level = LOG_LEVEL_CRITICAL; log_level <= LOG_LEVEL_VERBOSE; log_level++)
+    {
+        if (log_level > LOG_LEVEL_WARNING)
+        {
+            test_case_log_sink_callback_is_not_called_with_max_level(log_level, LOG_LEVEL_WARNING);
+        }
+        else
+        {
+            test_case_log_sink_callback_is_called_with_max_level(log_level, LOG_LEVEL_WARNING);
+        }
+    }
+}
+
+static void log_sink_callback_log_calls_callback_for_all_log_levels_ERROR_and_lower_when_max_level_is_ERROR(void)
+{
+    for (LOG_LEVEL log_level = LOG_LEVEL_CRITICAL; log_level <= LOG_LEVEL_VERBOSE; log_level++)
+    {
+        if (log_level > LOG_LEVEL_ERROR)
+        {
+            test_case_log_sink_callback_is_not_called_with_max_level(log_level, LOG_LEVEL_ERROR);
+        }
+        else
+        {
+            test_case_log_sink_callback_is_called_with_max_level(log_level, LOG_LEVEL_ERROR);
+        }
+    }
+}
+
+static void log_sink_callback_log_calls_callback_for_log_level_CRITICAL_when_max_level_is_CRITICAL(void)
+{
+    for (LOG_LEVEL log_level = LOG_LEVEL_CRITICAL; log_level <= LOG_LEVEL_VERBOSE; log_level++)
+    {
+        if (log_level > LOG_LEVEL_CRITICAL)
+        {
+            test_case_log_sink_callback_is_not_called_with_max_level(log_level, LOG_LEVEL_CRITICAL);
+        }
+        else
+        {
+            test_case_log_sink_callback_is_called_with_max_level(log_level, LOG_LEVEL_CRITICAL);
+        }
+    }
+}
+
 /* very "poor man's" way of testing, as no test harness and mocking framework are available */
 int main(void)
 {
@@ -416,6 +516,12 @@ int main(void)
 
     log_sink_callback_with_a_context_with_boolean_true_works();
     log_sink_callback_with_a_context_with_boolean_false_works();
+
+    log_sink_callback_log_calls_callback_for_all_log_levels_when_max_level_is_VERBOSE();
+    log_sink_callback_log_calls_callback_for_all_log_levels_INFO_and_lower_when_max_level_is_INFO();
+    log_sink_callback_log_calls_callback_for_all_log_levels_WARNING_and_lower_when_max_level_is_WARNING();
+    log_sink_callback_log_calls_callback_for_all_log_levels_ERROR_and_lower_when_max_level_is_ERROR();
+    log_sink_callback_log_calls_callback_for_log_level_CRITICAL_when_max_level_is_CRITICAL();
 
     log_sink_callback.deinit();
 

--- a/v2/tests/log_sink_callback_ut/log_sink_callback_ut.c
+++ b/v2/tests/log_sink_callback_ut/log_sink_callback_ut.c
@@ -1446,6 +1446,7 @@ int main(void)
     when_printing_a_property_value_exceeds_log_line_size_it_is_truncated();
     when_printing_a_property_name_exceeds_log_line_size_it_is_truncated();
 
+
     log_sink_callback_log_calls_callback_for_all_log_levels_when_max_level_is_VERBOSE();
     log_sink_callback_log_calls_callback_for_all_log_levels_INFO_and_lower_when_max_level_is_INFO();
     log_sink_callback_log_calls_callback_for_all_log_levels_WARNING_and_lower_when_max_level_is_WARNING();

--- a/v2/tests/log_sink_callback_ut/log_sink_callback_ut.c
+++ b/v2/tests/log_sink_callback_ut/log_sink_callback_ut.c
@@ -1446,7 +1446,6 @@ int main(void)
     when_printing_a_property_value_exceeds_log_line_size_it_is_truncated();
     when_printing_a_property_name_exceeds_log_line_size_it_is_truncated();
 
-
     log_sink_callback_log_calls_callback_for_all_log_levels_when_max_level_is_VERBOSE();
     log_sink_callback_log_calls_callback_for_all_log_levels_INFO_and_lower_when_max_level_is_INFO();
     log_sink_callback_log_calls_callback_for_all_log_levels_WARNING_and_lower_when_max_level_is_WARNING();


### PR DESCRIPTION
Adds function `log_sink_callback_set_max_level` to set the max log level.
No string processing is done when log level is above the max.