### PR TITLE
Test repo_validation fix from c-build-tools

### DIFF
--- a/build/devops_gated.yml
+++ b/build/devops_gated.yml
@@ -22,7 +22,7 @@ resources:
     type: github
     name: azure/c-build-tools
     endpoint: github.com_azure
-    ref: 09467f6f862a851fff5d01821f81fa285a7ea994
+    ref: c13048b2f5f2faad795739ba07d7ea4b93151725
 
 jobs:
 - template: /pipeline_templates/build_all_flavors.yml@c_build_tools

--- a/build/devops_gated.yml
+++ b/build/devops_gated.yml
@@ -22,7 +22,7 @@ resources:
     type: github
     name: azure/c-build-tools
     endpoint: github.com_azure
-    ref: 09467f6
+    ref: 09467f6f862a851fff5d01821f81fa285a7ea994
 
 jobs:
 - template: /pipeline_templates/build_all_flavors.yml@c_build_tools

--- a/build/devops_gated.yml
+++ b/build/devops_gated.yml
@@ -22,7 +22,7 @@ resources:
     type: github
     name: azure/c-build-tools
     endpoint: github.com_azure
-    ref: 61a603bed806edd8a3dc2f335a67314129fe59e2
+    ref: 09467f6
 
 jobs:
 - template: /pipeline_templates/build_all_flavors.yml@c_build_tools


### PR DESCRIPTION
Point to c-build-tools commit 09467f6 which uses a fixed 'repo_validation' target name, so the pipeline no longer needs a validation_msbuild_target parameter.