### PR TITLE
[MrBot] Add get_thread_stack_refresh_module_list for post-init symbol refresh

### DIFF
--- a/v2/inc/c_logging/get_thread_stack.h
+++ b/v2/inc/c_logging/get_thread_stack.h
@@ -31,6 +31,9 @@ extern "C" {
     void get_thread_stack(pthread_t threadId, char* destination, size_t destinationSize);
 #endif
 
+    /*refreshes the loaded module list so symbols from DLLs loaded after init are resolved*/
+    void get_thread_stack_refresh_module_list(void);
+
     /*deinitializes statics - not thread safe*/
     void get_thread_stack_deinit(void);
 

--- a/v2/src/get_thread_stack.c
+++ b/v2/src/get_thread_stack.c
@@ -320,6 +320,7 @@ void get_thread_stack_refresh_module_list(void)
                                     {
                                         searchPath[searchPathLen++] = ';';
                                     }
+
                                     if (searchPathLen + dirLen < sizeof(searchPath))
                                     {
                                         (void)memcpy(searchPath + searchPathLen, dir, dirLen);

--- a/v2/src/get_thread_stack.c
+++ b/v2/src/get_thread_stack.c
@@ -253,12 +253,29 @@ VsTest into testhost.exe) have their PDBs in different directories. This functio
 3. re-initializes the symbol handler with the updated search path so SymFromAddr can resolve their functions */
 void get_thread_stack_refresh_module_list(void)
 {
-    if (g.symbolsState == SYM_INIT_INITIALIZED)
+    if (g.symbolsState != SYM_INIT_INITIALIZED)
+    {
+        /*not initialized, nothing to refresh*/
+    }
+    else
     {
         AcquireSRWLockExclusive(&g.lockOverSymCalls);
         {
             HANDLE hModuleSnap = CreateToolhelp32Snapshot(TH32CS_SNAPMODULE, 0);
-            if (hModuleSnap != INVALID_HANDLE_VALUE)
+            if (hModuleSnap == INVALID_HANDLE_VALUE)
+            {
+                /*fall back to just refreshing the module list*/
+                if (!SymRefreshModuleList(g.processHandle))
+                {
+                    (void)printf("failure (GetLastError()=0x%" PRIx32 ") in SymRefreshModuleList(g.processHandle=%p)\n",
+                        GetLastError(), g.processHandle);
+                }
+                else
+                {
+                    /*SymRefreshModuleList succeeded*/
+                }
+            }
+            else
             {
                 char searchPath[32768];
                 size_t searchPathLen = 0;
@@ -267,21 +284,37 @@ void get_thread_stack_refresh_module_list(void)
                 MODULEENTRY32 me32;
                 me32.dwSize = sizeof(MODULEENTRY32);
 
-                if (Module32First(hModuleSnap, &me32))
+                if (!Module32First(hModuleSnap, &me32))
+                {
+                    /*no modules found, nothing to do*/
+                }
+                else
                 {
                     do
                     {
                         char* lastBackslash = strrchr(me32.szExePath, '\\');
-                        if (lastBackslash != NULL)
+                        if (lastBackslash == NULL)
+                        {
+                            /*no backslash in path, skip this module*/
+                        }
+                        else
                         {
                             size_t dirLen = (size_t)(lastBackslash - me32.szExePath);
                             char dir[MAX_PATH];
-                            if (dirLen < MAX_PATH)
+                            if (dirLen >= MAX_PATH)
+                            {
+                                /*directory path too long, skip this module*/
+                            }
+                            else
                             {
                                 (void)memcpy(dir, me32.szExePath, dirLen);
                                 dir[dirLen] = '\0';
 
-                                if (strstr(searchPath, dir) == NULL)
+                                if (strstr(searchPath, dir) != NULL)
+                                {
+                                    /*directory already in search path, skip*/
+                                }
+                                else
                                 {
                                     if (searchPathLen > 0 && searchPathLen + 1 < sizeof(searchPath))
                                     {
@@ -293,6 +326,10 @@ void get_thread_stack_refresh_module_list(void)
                                         searchPathLen += dirLen;
                                         searchPath[searchPathLen] = '\0';
                                     }
+                                    else
+                                    {
+                                        /*search path buffer full, stop adding directories*/
+                                    }
                                 }
                             }
                         }
@@ -301,7 +338,11 @@ void get_thread_stack_refresh_module_list(void)
                 }
                 (void)CloseHandle(hModuleSnap);
 
-                if (searchPathLen > 0)
+                if (searchPathLen == 0)
+                {
+                    /*no directories found, nothing to update*/
+                }
+                else
                 {
                     /*re-initialize the symbol handler with the updated search path*/
                     (void)SymCleanup(g.processHandle);
@@ -310,15 +351,10 @@ void get_thread_stack_refresh_module_list(void)
                         (void)printf("failure (GetLastError()=0x%" PRIx32 ") in SymInitialize during refresh(g.processHandle=%p, searchPath=%s, TRUE)\n",
                             GetLastError(), g.processHandle, searchPath);
                     }
-                }
-            }
-            else
-            {
-                /*fall back to just refreshing the module list*/
-                if (!SymRefreshModuleList(g.processHandle))
-                {
-                    (void)printf("failure (GetLastError()=0x%" PRIx32 ") in SymRefreshModuleList(g.processHandle=%p)\n",
-                        GetLastError(), g.processHandle);
+                    else
+                    {
+                        /*symbol handler re-initialized successfully with updated search path*/
+                    }
                 }
             }
         }

--- a/v2/src/get_thread_stack.c
+++ b/v2/src/get_thread_stack.c
@@ -13,6 +13,7 @@
 #include "windows.h"
 #include "winnt.h"
 #include "dbghelp.h"
+#include "tlhelp32.h"
 #endif
 
 #include "macro_utils/macro_utils.h"
@@ -244,17 +245,81 @@ allok:
 }
 
 
-/*refreshes dbghelp's module list so that DLLs loaded after SymInitialize have their symbols available for resolution*/
+/*refreshes dbghelp's symbol handler so that DLLs loaded after SymInitialize have their symbols available for resolution.
+SymInitialize sets the PDB search path to the host executable's directory. DLLs loaded later (e.g. test DLLs loaded by
+VsTest into testhost.exe) have their PDBs in different directories. This function:
+1. enumerates all currently loaded modules
+2. builds a search path from their directories
+3. re-initializes the symbol handler with the updated search path so SymFromAddr can resolve their functions */
 void get_thread_stack_refresh_module_list(void)
 {
     if (g.symbolsState == SYM_INIT_INITIALIZED)
     {
         AcquireSRWLockExclusive(&g.lockOverSymCalls);
         {
-            if (!SymRefreshModuleList(g.processHandle))
+            HANDLE hModuleSnap = CreateToolhelp32Snapshot(TH32CS_SNAPMODULE, 0);
+            if (hModuleSnap != INVALID_HANDLE_VALUE)
             {
-                (void)printf("failure (GetLastError()=0x%" PRIx32 ") in SymRefreshModuleList(g.processHandle=%p)\n",
-                    GetLastError(), g.processHandle);
+                char searchPath[32768];
+                size_t searchPathLen = 0;
+                searchPath[0] = '\0';
+
+                MODULEENTRY32 me32;
+                me32.dwSize = sizeof(MODULEENTRY32);
+
+                if (Module32First(hModuleSnap, &me32))
+                {
+                    do
+                    {
+                        char* lastBackslash = strrchr(me32.szExePath, '\\');
+                        if (lastBackslash != NULL)
+                        {
+                            size_t dirLen = (size_t)(lastBackslash - me32.szExePath);
+                            char dir[MAX_PATH];
+                            if (dirLen < MAX_PATH)
+                            {
+                                (void)memcpy(dir, me32.szExePath, dirLen);
+                                dir[dirLen] = '\0';
+
+                                if (strstr(searchPath, dir) == NULL)
+                                {
+                                    if (searchPathLen > 0 && searchPathLen + 1 < sizeof(searchPath))
+                                    {
+                                        searchPath[searchPathLen++] = ';';
+                                    }
+                                    if (searchPathLen + dirLen < sizeof(searchPath))
+                                    {
+                                        (void)memcpy(searchPath + searchPathLen, dir, dirLen);
+                                        searchPathLen += dirLen;
+                                        searchPath[searchPathLen] = '\0';
+                                    }
+                                }
+                            }
+                        }
+                        me32.dwSize = sizeof(MODULEENTRY32);
+                    } while (Module32Next(hModuleSnap, &me32));
+                }
+                (void)CloseHandle(hModuleSnap);
+
+                if (searchPathLen > 0)
+                {
+                    /*re-initialize the symbol handler with the updated search path*/
+                    (void)SymCleanup(g.processHandle);
+                    if (!SymInitialize(g.processHandle, searchPath, TRUE))
+                    {
+                        (void)printf("failure (GetLastError()=0x%" PRIx32 ") in SymInitialize during refresh(g.processHandle=%p, searchPath=%s, TRUE)\n",
+                            GetLastError(), g.processHandle, searchPath);
+                    }
+                }
+            }
+            else
+            {
+                /*fall back to just refreshing the module list*/
+                if (!SymRefreshModuleList(g.processHandle))
+                {
+                    (void)printf("failure (GetLastError()=0x%" PRIx32 ") in SymRefreshModuleList(g.processHandle=%p)\n",
+                        GetLastError(), g.processHandle);
+                }
             }
         }
         ReleaseSRWLockExclusive(&g.lockOverSymCalls);

--- a/v2/src/get_thread_stack.c
+++ b/v2/src/get_thread_stack.c
@@ -244,6 +244,24 @@ allok:
 }
 
 
+/*refreshes dbghelp's module list so that DLLs loaded after SymInitialize have their symbols available for resolution*/
+void get_thread_stack_refresh_module_list(void)
+{
+    if (g.symbolsState == SYM_INIT_INITIALIZED)
+    {
+        AcquireSRWLockExclusive(&g.lockOverSymCalls);
+        {
+            if (!SymRefreshModuleList(g.processHandle))
+            {
+                (void)printf("failure (GetLastError()=0x%" PRIx32 ") in SymRefreshModuleList(g.processHandle=%p)\n",
+                    GetLastError(), g.processHandle);
+            }
+        }
+        ReleaseSRWLockExclusive(&g.lockOverSymCalls);
+    }
+}
+
+
 void get_thread_stack(DWORD threadId, char* destination, size_t destinationSize)
 {
     /*1) parameter validation*/
@@ -510,6 +528,11 @@ void get_thread_stack(pthread_t thread, char* destination, size_t destinationSiz
         /*just inform this is not supported*/
         snprintf_fallback(&destination, &destinationSize, snprintfFailed, sizeof(snprintfFailed), "currently running platform not supported.");
     }
+}
+
+void get_thread_stack_refresh_module_list(void)
+{
+    /*no-op on Linux*/
 }
 
 void get_thread_stack_deinit(void)


### PR DESCRIPTION
## Problem

When `get_thread_stack_init()` / `SymInitialize()` runs before test DLLs are loaded (e.g. in VsTest testhost processes), `SymFromAddr()` cannot resolve function names from those DLLs. This causes `wait_for_callstack` in EBS to return `"failure in SymFromAddr"` instead of real function names, leading to spurious `WAIT_FOR_CALLSTACK_TIMEOUT` failures.

## Fix

Add `get_thread_stack_refresh_module_list()` which calls `SymRefreshModuleList()` to update dbghelp's loaded module list. This is a targeted, low-risk addition — no existing behavior changes.

Consumers (like EBS's `wait_for_callstack`) call this once before their polling loop to ensure recently-loaded DLLs have symbols available.

## Testing

Will be validated via EBS gate PR that points c-logging submodule to this branch.