### PR TITLE
Add macOS (APPLE) stub support for get_thread_stack

### DIFF
--- a/v2/inc/c_logging/get_thread_stack.h
+++ b/v2/inc/c_logging/get_thread_stack.h
@@ -12,7 +12,7 @@
 
 #if defined(_MSC_VER)
 #include "windows.h" /*needed for DWORD*/
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__APPLE__)
 #include <pthread.h> /*needed for pthread_t*/
 #else
 #error no other platform supported
@@ -27,7 +27,7 @@ extern "C" {
 
 #if defined(_MSC_VER)
     void get_thread_stack(DWORD threadId, char* destination, size_t destinationSize);
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__APPLE__)
     void get_thread_stack(pthread_t threadId, char* destination, size_t destinationSize);
 #endif
 

--- a/v2/src/get_thread_stack.c
+++ b/v2/src/get_thread_stack.c
@@ -608,7 +608,7 @@ void get_thread_stack_deinit(void)
     }
 }
 
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__APPLE__)
 /*for all the others we don't provide a way to inspect another thread's call stack (yet).*/
 
 int get_thread_stack_init(void)


### PR DESCRIPTION
macOS uses pthreads like Linux. The stub implementation returns 0 for init and prints 'not supported' for stack traces, matching the existing Linux behavior. This unblocks c-utility and downstream repos building and running tests on macOS.