### PR TITLE
[MrBot] Bump Windows ARM64 pool to Dpldsv6-v04

### DIFF
--- a/build/devops_gated.yml
+++ b/build/devops_gated.yml
@@ -8,7 +8,7 @@ parameters:
   - name: pool_name_windows_arm64
     displayName: 'Windows ARM64 Pool'
     type: string
-    default: 'Azure-MessagingStore-Win-ARM64-Dpldsv6-v01'
+    default: 'Azure-MessagingStore-Win-ARM64-Dpldsv6-v04'
   - name: pool_name_linux
     displayName: 'Linux Pool'
     type: string


### PR DESCRIPTION
Replace pool `Azure-MessagingStore-Win-ARM64-Dpldsv6-v01` with `Azure-MessagingStore-Win-ARM64-Dpldsv6-v04` in the gated build pipeline.