### PR TITLE
[MrBot][build] Retry git checkout steps on transient network failures

### DIFF
--- a/build/devops_gated.yml
+++ b/build/devops_gated.yml
@@ -56,6 +56,8 @@ jobs:
 
   # Shallow clone - only need the code at this commit, not full history
   - checkout: self
+    # Retry on failure to handle transient network connection failures (curl 56 / early EOF).
+    retryCountOnTaskFailure: 3
     submodules: false
     clean: false
     fetchDepth: 1


### PR DESCRIPTION
## Summary
Broadly applies the transient git-checkout retry fix from [ELS PR 16293811](https://msazure.visualstudio.com/One/_git/Azure-Messaging-ElasticLog/pullrequest/16293811) to this repo's pipeline YAML.

The pipeline `checkout:` step now sets `retryCountOnTaskFailure: 3`, so a transient network failure during Get Sources / submodule fetch (e.g. `curl 56 Recv failure: Connection was reset` -> `fatal: early EOF`) is retried automatically instead of failing the leg.

## Change (build-YAML only)
- Added `retryCountOnTaskFailure: 3` to the git `checkout:` step, preceded by a brief comment.

## Verification
- YAML parse: PASS on the changed file.
- Purely additive (2 lines, 0 deletions).
